### PR TITLE
Fix uloaddate and force Enables list

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/Madara6Parser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/Madara6Parser.kt
@@ -57,8 +57,9 @@ internal abstract class Madara6Parser(
 				name = a.text(),
 				number = i + 1,
 				branch = null,
-				uploadDate = dateFormat.tryParse(
-					li.selectFirst(".chapter-release-date")?.text()?.trim(),
+				uploadDate = parseChapterDate(
+					dateFormat,
+					li.selectFirst("span.chapter-release-date i")?.text(),
 				),
 				scanlator = null,
 				source = source,

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/Madara6Parser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/Madara6Parser.kt
@@ -50,7 +50,7 @@ internal abstract class Madara6Parser(
 		val doc = webClient.httpPost(url, emptyMap()).parseHtml()
 		return doc.select("li.wp-manga-chapter").mapChapters(reversed = true) { i, li ->
 			val a = li.selectFirstOrThrow("a")
-			val href = a.attrAsRelativeUrl("href")
+			val href = a.attrAsRelativeUrl("href") + "?style=list"
 			MangaChapter(
 				id = generateUid(href),
 				url = href,


### PR DESCRIPTION
allows you to use the function in madaraparser to fix dates, e.g. "2 hours ago", otherwise the app wouldn't display the chapters.