### PR TITLE
New parser: TuMangaOnline

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/network/OkHttpWebClient.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/network/OkHttpWebClient.kt
@@ -23,9 +23,7 @@ class OkHttpWebClient(
 			.get()
 			.url(url)
 			.addTags()
-		if (extraHeaders != null) {
-			request.headers(extraHeaders)
-		}
+			.addExtraHeaders(extraHeaders)
 		return httpClient.newCall(request.build()).await().ensureSuccess()
 	}
 
@@ -37,7 +35,7 @@ class OkHttpWebClient(
 		return httpClient.newCall(request.build()).await().ensureSuccess()
 	}
 
-	override suspend fun httpPost(url: HttpUrl, form: Map<String, String>): Response {
+	override suspend fun httpPost(url: HttpUrl, form: Map<String, String>, extraHeaders: Headers?): Response {
 		val body = FormBody.Builder()
 		form.forEach { (k, v) ->
 			body.addEncoded(k, v)
@@ -46,10 +44,11 @@ class OkHttpWebClient(
 			.post(body.build())
 			.url(url)
 			.addTags()
+			.addExtraHeaders(extraHeaders)
 		return httpClient.newCall(request.build()).await().ensureSuccess()
 	}
 
-	override suspend fun httpPost(url: HttpUrl, payload: String): Response {
+	override suspend fun httpPost(url: HttpUrl, payload: String, extraHeaders: Headers?): Response {
 		val body = FormBody.Builder()
 		payload.split('&').forEach {
 			val pos = it.indexOf('=')
@@ -63,16 +62,18 @@ class OkHttpWebClient(
 			.post(body.build())
 			.url(url)
 			.addTags()
+			.addExtraHeaders(extraHeaders)
 		return httpClient.newCall(request.build()).await().ensureSuccess()
 	}
 
-	override suspend fun httpPost(url: HttpUrl, body: JSONObject): Response {
+	override suspend fun httpPost(url: HttpUrl, body: JSONObject, extraHeaders: Headers?): Response {
 		val mediaType = "application/json; charset=utf-8".toMediaType()
 		val requestBody = body.toString().toRequestBody(mediaType)
 		val request = Request.Builder()
 			.post(requestBody)
 			.url(url)
 			.addTags()
+			.addExtraHeaders(extraHeaders)
 		return httpClient.newCall(request.build()).await().ensureSuccess()
 	}
 
@@ -99,6 +100,13 @@ class OkHttpWebClient(
 
 	private fun Request.Builder.addTags(): Request.Builder {
 		tag(MangaSource::class.java, mangaSource)
+		return this
+	}
+
+	private fun Request.Builder.addExtraHeaders(headers: Headers?): Request.Builder {
+		if (headers != null) {
+			headers(headers)
+		}
 		return this
 	}
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/network/RateLimitInterceptor.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/network/RateLimitInterceptor.kt
@@ -1,0 +1,79 @@
+package org.koitharu.kotatsu.parsers.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.internal.notifyAll
+import okio.IOException
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+
+// TODO rewrite this
+class RateLimitInterceptor : Interceptor {
+
+	private val requestQueue = ArrayDeque<Long>(10)
+	private val rateLimitMillis = TimeUnit.SECONDS.toMillis(60L)
+	private val fairLock = Semaphore(1, true)
+
+	override fun intercept(chain: Interceptor.Chain): Response {
+		val call = chain.call()
+		val request = chain.request()
+
+		try {
+			fairLock.acquire()
+		} catch (e: InterruptedException) {
+			throw IOException(e)
+		}
+
+		val requestQueue = this.requestQueue
+		val timestamp: Long
+
+		try {
+			synchronized(requestQueue) {
+				while (requestQueue.size >= 10) {
+					val periodStart = System.currentTimeMillis() - rateLimitMillis
+					var hasRemovedExpired = false
+					while (requestQueue.isEmpty().not() && requestQueue.first() <= periodStart) {
+						requestQueue.removeFirst()
+						hasRemovedExpired = true
+					}
+					if (call.isCanceled()) {
+						throw IOException("Canceled")
+					} else if (hasRemovedExpired) {
+						break
+					} else {
+						try {
+							requestQueue.wait(requestQueue.first() - periodStart)
+						} catch (_: InterruptedException) {
+							continue
+						}
+					}
+				}
+
+				timestamp = System.currentTimeMillis()
+				requestQueue.addLast(timestamp)
+			}
+		} finally {
+			fairLock.release()
+		}
+
+		val response = chain.proceed(request)
+		if (response.networkResponse == null) {
+			synchronized(requestQueue) {
+				if (requestQueue.isEmpty() || timestamp < requestQueue.first()) return@synchronized
+				val iterator = requestQueue.iterator()
+				while (iterator.hasNext()) {
+					if (iterator.next() == timestamp) {
+						iterator.remove()
+						break
+					}
+				}
+				requestQueue.notifyAll()
+			}
+		}
+
+		return response
+	}
+
+	@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN", "NOTHING_TO_INLINE")
+	private inline fun Any.wait(timeout: Long) = (this as Object).wait(timeout)
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/network/WebClient.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/network/WebClient.kt
@@ -22,6 +22,11 @@ interface WebClient {
 	 */
 	suspend fun httpGet(url: HttpUrl): Response = httpGet(url, null)
 
+	/**
+	 * Do a GET http request to specific url
+	 * @param url
+	 * @param extraHeaders additional HTTP headers for request
+	 */
 	suspend fun httpGet(url: HttpUrl, extraHeaders: Headers?): Response
 
 	/**
@@ -41,42 +46,66 @@ interface WebClient {
 	 * @param url
 	 * @param form payload as key=>value map
 	 */
-	suspend fun httpPost(url: String, form: Map<String, String>): Response = httpPost(url.toHttpUrl(), form)
+	suspend fun httpPost(url: String, form: Map<String, String>): Response = httpPost(url.toHttpUrl(), form, null)
 
 	/**
 	 * Do a POST http request to specific url with `multipart/form-data` payload
 	 * @param url
 	 * @param form payload as key=>value map
 	 */
-	suspend fun httpPost(url: HttpUrl, form: Map<String, String>): Response
+	suspend fun httpPost(url: HttpUrl, form: Map<String, String>): Response = httpPost(url, form, null)
+
+	/**
+	 * Do a POST http request to specific url with `multipart/form-data` payload
+	 * @param url
+	 * @param form payload as key=>value map
+	 * @param extraHeaders additional HTTP headers for request
+	 */
+	suspend fun httpPost(url: HttpUrl, form: Map<String, String>, extraHeaders: Headers?): Response
 
 	/**
 	 * Do a POST http request to specific url with `multipart/form-data` payload
 	 * @param url
 	 * @param payload payload as `key=value` string with `&` separator
 	 */
-	suspend fun httpPost(url: String, payload: String): Response = httpPost(url.toHttpUrl(), payload)
+	suspend fun httpPost(url: String, payload: String): Response = httpPost(url.toHttpUrl(), payload, null)
 
 	/**
 	 * Do a POST http request to specific url with `multipart/form-data` payload
 	 * @param url
 	 * @param payload payload as `key=value` string with `&` separator
 	 */
-	suspend fun httpPost(url: HttpUrl, payload: String): Response
+	suspend fun httpPost(url: HttpUrl, payload: String): Response = httpPost(url, payload, null)
+
+	/**
+	 * Do a POST http request to specific url with `multipart/form-data` payload
+	 * @param url
+	 * @param payload payload as `key=value` string with `&` separator
+	 * @param extraHeaders additional HTTP headers for request
+	 */
+	suspend fun httpPost(url: HttpUrl, payload: String, extraHeaders: Headers?): Response
 
 	/**
 	 * Do a POST http request to specific url with json payload
 	 * @param url
 	 * @param body
 	 */
-	suspend fun httpPost(url: String, body: JSONObject): Response = httpPost(url.toHttpUrl(), body)
+	suspend fun httpPost(url: String, body: JSONObject): Response = httpPost(url.toHttpUrl(), body, null)
 
 	/**
 	 * Do a POST http request to specific url with json payload
 	 * @param url
 	 * @param body
 	 */
-	suspend fun httpPost(url: HttpUrl, body: JSONObject): Response
+	suspend fun httpPost(url: HttpUrl, body: JSONObject): Response = httpPost(url, body, null)
+
+	/**
+	 * Do a POST http request to specific url with json payload
+	 * @param url
+	 * @param body
+	 * @param extraHeaders additional HTTP headers for request
+	 */
+	suspend fun httpPost(url: HttpUrl, body: JSONObject, extraHeaders: Headers?): Response
 
 	/**
 	 * Do a GraphQL request to specific url

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/BentomangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/BentomangaParser.kt
@@ -202,7 +202,7 @@ internal class BentomangaParser(context: MangaLoaderContext) : PagedMangaParser(
 	private fun parseChapters(root: Element): List<MangaChapter> {
 		return root.requireElementById("chapters_content")
 			.select(".component-chapter").map { div ->
-				val a = div.selectFirstOrThrow("a")
+				val a = div.selectFirstOrThrow("a:not([style*='display:none'])")
 				val href = a.attrAsRelativeUrl("href")
 				val title = div.selectFirstOrThrow(".chapter_volume").text()
 				val name = div.selectFirst(".chapter_title")?.textOrNull()

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/TuMangaOnlineParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/TuMangaOnlineParser.kt
@@ -1,0 +1,339 @@
+package org.koitharu.kotatsu.parsers.site
+
+import android.os.SystemClock
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.koitharu.kotatsu.core.util.ext.ensureSuccess
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.PagedMangaParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.RATING_UNKNOWN
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.network.WebClient
+import org.koitharu.kotatsu.parsers.util.attrAsAbsoluteUrlOrNull
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
+import org.koitharu.kotatsu.parsers.util.await
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.host
+import org.koitharu.kotatsu.parsers.util.mapChapters
+import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.tryParse
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.EnumSet
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+
+@MangaSourceParser("TUMANGAONLINE", "TuMangaOnline", "es")
+class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
+	context,
+	source = MangaSource.TUMANGAONLINE,
+	pageSize = 24,
+), Interceptor {
+
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("lectortmo.com")
+
+	private val chapterDateFormat = SimpleDateFormat("yyyy-MM-dd", sourceLocale)
+
+	override val sortOrders: Set<SortOrder>
+		get() = EnumSet.of(
+			SortOrder.NEWEST,
+			SortOrder.POPULARITY,
+		)
+
+	private val requestQueue = ArrayDeque<Long>(permits)
+	private val rateLimitMillis = unit.toMillis(period)
+	private val fairLock = Semaphore(1, true)
+
+	override fun intercept(chain: Interceptor.Chain): Response {
+		val call = chain.call()
+		if (call.isCanceled()) throw IOException("Canceled")
+
+		val request = chain.request()
+		when (domain) {
+			request.url.host -> {}
+			else -> return chain.proceed(request)
+		}
+
+		try {
+			fairLock.acquire()
+		} catch (e: InterruptedException) {
+			throw IOException(e)
+		}
+
+		val requestQueue = this.requestQueue
+		val timestamp: Long
+
+		try {
+			synchronized(requestQueue) {
+				while (requestQueue.size >= permits) {
+					val periodStart = SystemClock.elapsedRealtime() - rateLimitMillis
+					var hasRemovedExpired = false
+					while (requestQueue.isEmpty().not() && requestQueue.first() <= periodStart) {
+						requestQueue.removeFirst()
+						hasRemovedExpired = true
+					}
+					if (call.isCanceled()) {
+						throw IOException("Canceled")
+					} else if (hasRemovedExpired) {
+						break
+					} else {
+						try {
+							(requestQueue as Object).wait(requestQueue.first() - periodStart)
+						} catch (_: InterruptedException) {
+							continue
+						}
+					}
+				}
+
+				timestamp = SystemClock.elapsedRealtime()
+				requestQueue.addLast(timestamp)
+			}
+		} finally {
+			fairLock.release()
+		}
+
+		val response = chain.proceed(request)
+		if (response.networkResponse == null) {
+			synchronized(requestQueue) {
+				if (requestQueue.isEmpty() || timestamp < requestQueue.first()) return@synchronized
+				val iterator = requestQueue.iterator()
+				while (iterator.hasNext()) {
+					if (iterator.next() == timestamp) {
+						iterator.remove()
+						break
+					}
+				}
+				(requestQueue as Object).notifyAll()
+			}
+		}
+
+		return response
+	}
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder
+	): List<Manga> {
+		val url = buildString {
+			append("/library")
+			if(query.isNullOrEmpty()){
+				append("?order_item=")
+				if (sortOrder == SortOrder.POPULARITY) {
+					append("likes_count")
+				}
+				if (sortOrder == SortOrder.NEWEST) {
+					append("creation")
+				}
+				append("&order_dir=desc")
+				append("&filter_by=title")
+				if (tags != null) {
+					for(tag in tags){
+						append("&genders[]=${tag.key}")
+					}
+				}
+			} else {
+				append("?title=$query")
+			}
+			append("&_pg=1")
+			append("&page=$page")
+		}.toAbsoluteUrl(domain)
+
+		val doc = webClient.httpGet(url, headers).parseHtml()
+		val items = doc.body().select("div.element")
+		return items.mapNotNull { item ->
+			val href = item.selectFirst("a")?.attrAsRelativeUrlOrNull("href")?.substringAfter(' ') ?: return@mapNotNull null
+			Manga(
+				id = generateUid(href),
+				title = item.selectFirst("h4.text-truncate")?.text() ?: return@mapNotNull null,
+				coverUrl = item.select("style").toString().substringAfter("('").substringBeforeLast("')"),
+				altTitle = null,
+				author = null,
+				rating = item.selectFirst("span.score")
+					?.text()
+					?.toFloatOrNull()
+					?.div(10F) ?: RATING_UNKNOWN,
+				url = href,
+				isNsfw = item.select("i").hasClass("fas fa-heartbeat fa-2x"),
+				tags = emptySet(),
+				state = null,
+				publicUrl = href.toAbsoluteUrl(doc.host ?: domain),
+				source = source,
+			)
+		}
+
+	}
+
+	override suspend fun getDetails(manga: Manga): Manga {
+		val doc = webClient.httpGet(manga.url.toAbsoluteUrl(domain)).parseHtml()
+		val contents = doc.body().selectFirstOrThrow("section.element-header-content")
+		return manga.copy(
+			description = contents.selectFirst("p.element-description")?.html(),
+			largeCoverUrl = contents.selectFirst(".book-thumbnail")?.attrAsAbsoluteUrlOrNull("src"),
+			state = parseStatus(contents.select("span.book-status").text().orEmpty()),
+			author = contents.selectFirst("h5.card-title")?.attr("title")?.substringAfter(", "),
+			chapters = if(doc.select("div.chapters").isEmpty()){
+				doc.select(oneShotChapterListSelector()).mapChapters(reversed = true) { i, item ->
+					oneShotChapterFromElement(item)
+				}
+			} else {
+				val chapters = mutableListOf<MangaChapter>()
+				doc.select(regularChapterListSelector()).reversed().forEachIndexed { i, item ->
+					val chaptername = item.select("div.col-10.text-truncate").text().replace("&nbsp;", " ").trim()
+					val scanelement = item.select("ul.chapter-list > li")
+					scanelement.forEach { chapters.add(regularChapterFromElement(it, chaptername, i)) }
+				}
+				chapters
+			}
+		)
+	}
+
+	private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
+	private fun oneShotChapterFromElement(element: Element): MangaChapter {
+		val href = element.selectFirstOrThrow("div.row > .text-right > a")
+			.attrAsRelativeUrl("href")
+		return MangaChapter(
+			id = generateUid(href),
+			name = "One Shot",
+			number = 1,
+			url = href,
+			scanlator = element.select("div.col-md-6.text-truncate").text(),
+			branch = null,
+			uploadDate = chapterDateFormat.tryParse(element.select("span.badge.badge-primary.p-2").first()?.text()),
+			source = source,
+		)
+	}
+
+	private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
+	private fun regularChapterFromElement(element: Element, chName: String, number: Int): MangaChapter {
+		val href = element.selectFirstOrThrow("div.row > .text-right > a")
+			.attrAsRelativeUrl("href")
+		return MangaChapter(
+			id = generateUid(href),
+			name = chName,
+			number = number + 1,
+			url = href,
+			scanlator = element.select("div.col-md-6.text-truncate").text(),
+			branch = null,
+			uploadDate = chapterDateFormat.tryParse(element.select("span.badge.badge-primary.p-2").first()?.text()),
+			source = source,
+		)
+	}
+
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val redirectDoc = webClient.httpGet(chapter.url.toAbsoluteUrl(domain), headers).parseHtml()
+		var doc = redirectToReadingPage(redirectDoc)
+		val currentUrl = doc.location()
+		val newUrl = if (!currentUrl.contains("cascade")) {
+			currentUrl.substringBefore("paginated") + "cascade"
+		} else {
+			currentUrl
+		}
+
+		if (currentUrl != newUrl) {
+			doc = webClient.httpGet(newUrl, headers).parseHtml()
+		}
+
+		return doc.select("div.viewer-container img:not(noscript img)").map{
+			val href = if (it.hasAttr("data-src")) {
+				it.attr("abs:data-src")
+			} else {
+				it.attr("abs:src")
+			}
+			MangaPage(
+				id = generateUid(href),
+				url = href,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+
+	private suspend fun redirectToReadingPage(document: Document): Document {
+		val script1 = document.selectFirst("script:containsData(uniqid)")
+		val script2 = document.selectFirst("script:containsData(window.location.replace)")
+
+		val redirectHeaders = Headers.Builder()
+			.set("Referer", document.baseUri())
+			.build()
+
+		if (script1 != null) {
+			val data = script1.data()
+			val regexParams = """\{uniqid:'(.+)',cascade:(.+)\}""".toRegex()
+			val regexAction = """form\.action\s?=\s?'(.+)'""".toRegex()
+			val params = regexParams.find(data)!!
+			val action = regexAction.find(data)!!.groupValues[1]
+
+			val formBody = FormBody.Builder()
+				.add("uniqid", params.groupValues[1])
+				.add("cascade", params.groupValues[2])
+				.build()
+
+			return redirectToReadingPage(webClient.httpPost(action,redirectHeaders,formBody).parseHtml())
+		}
+
+		if (script2 != null) {
+			val data = script2.data()
+			val regexRedirect = """window\.location\.replace\('(.+)'\)""".toRegex()
+			val url = regexRedirect.find(data)!!.groupValues[1]
+
+			return redirectToReadingPage(webClient.httpGet(url, redirectHeaders).parseHtml())
+		}
+
+		return document
+	}
+
+	override suspend fun getTags(): Set<MangaTag> {
+		val doc = webClient.httpGet("https://$domain/library", headers).parseHtml()
+		val elements = doc.body().select("div#books-genders > div > div")
+		return elements.mapNotNullToSet { element ->
+			MangaTag(
+				title = element.select("label").text(),
+				key = element.select("input").attr("value"),
+				source = source
+			)
+		}
+	}
+
+	private fun parseStatus(status: String) = when {
+		status.contains("Publicándose") -> MangaState.ONGOING
+		status.contains("Finalizado") -> MangaState.FINISHED
+		else -> null
+	}
+
+	private suspend fun WebClient.httpPost(url: String, headers: Headers, body: FormBody): Response {
+		val client = context.httpClient
+		val request = Request.Builder()
+			.post(body)
+			.headers(headers)
+			.url(url)
+		return client.newCall(request.build()).await().ensureSuccess()
+	}
+
+	companion object {
+		private const val permits = 10
+		private const val period = 60L
+		private val unit = TimeUnit.SECONDS
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/TuMangaOnlineParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/TuMangaOnlineParser.kt
@@ -1,143 +1,43 @@
 package org.koitharu.kotatsu.parsers.site
 
-import android.os.SystemClock
-import okhttp3.FormBody
 import okhttp3.Headers
-import okhttp3.Interceptor
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
-import org.koitharu.kotatsu.core.util.ext.ensureSuccess
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.PagedMangaParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
-import org.koitharu.kotatsu.parsers.model.Manga
-import org.koitharu.kotatsu.parsers.model.MangaChapter
-import org.koitharu.kotatsu.parsers.model.MangaPage
-import org.koitharu.kotatsu.parsers.model.MangaSource
-import org.koitharu.kotatsu.parsers.model.MangaState
-import org.koitharu.kotatsu.parsers.model.MangaTag
-import org.koitharu.kotatsu.parsers.model.RATING_UNKNOWN
-import org.koitharu.kotatsu.parsers.model.SortOrder
-import org.koitharu.kotatsu.parsers.network.WebClient
-import org.koitharu.kotatsu.parsers.util.attrAsAbsoluteUrlOrNull
-import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
-import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
-import org.koitharu.kotatsu.parsers.util.await
-import org.koitharu.kotatsu.parsers.util.domain
-import org.koitharu.kotatsu.parsers.util.generateUid
-import org.koitharu.kotatsu.parsers.util.host
-import org.koitharu.kotatsu.parsers.util.mapChapters
-import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
-import org.koitharu.kotatsu.parsers.util.parseHtml
-import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
-import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
-import org.koitharu.kotatsu.parsers.util.tryParse
-import java.io.IOException
+import org.koitharu.kotatsu.parsers.model.*
+import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
-import java.util.EnumSet
-import java.util.concurrent.Semaphore
-import java.util.concurrent.TimeUnit
+import java.util.*
 
 @MangaSourceParser("TUMANGAONLINE", "TuMangaOnline", "es")
-class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
+class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser(
 	context,
 	source = MangaSource.TUMANGAONLINE,
 	pageSize = 24,
-), Interceptor {
+) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("lectortmo.com")
+	override val configKeyDomain = ConfigKey.Domain("lectortmo.com")
 
 	private val chapterDateFormat = SimpleDateFormat("yyyy-MM-dd", sourceLocale)
 
-	override val sortOrders: Set<SortOrder>
-		get() = EnumSet.of(
-			SortOrder.NEWEST,
-			SortOrder.POPULARITY,
-		)
-
-	private val requestQueue = ArrayDeque<Long>(permits)
-	private val rateLimitMillis = unit.toMillis(period)
-	private val fairLock = Semaphore(1, true)
-
-	override fun intercept(chain: Interceptor.Chain): Response {
-		val call = chain.call()
-		if (call.isCanceled()) throw IOException("Canceled")
-
-		val request = chain.request()
-		when (domain) {
-			request.url.host -> {}
-			else -> return chain.proceed(request)
-		}
-
-		try {
-			fairLock.acquire()
-		} catch (e: InterruptedException) {
-			throw IOException(e)
-		}
-
-		val requestQueue = this.requestQueue
-		val timestamp: Long
-
-		try {
-			synchronized(requestQueue) {
-				while (requestQueue.size >= permits) {
-					val periodStart = SystemClock.elapsedRealtime() - rateLimitMillis
-					var hasRemovedExpired = false
-					while (requestQueue.isEmpty().not() && requestQueue.first() <= periodStart) {
-						requestQueue.removeFirst()
-						hasRemovedExpired = true
-					}
-					if (call.isCanceled()) {
-						throw IOException("Canceled")
-					} else if (hasRemovedExpired) {
-						break
-					} else {
-						try {
-							(requestQueue as Object).wait(requestQueue.first() - periodStart)
-						} catch (_: InterruptedException) {
-							continue
-						}
-					}
-				}
-
-				timestamp = SystemClock.elapsedRealtime()
-				requestQueue.addLast(timestamp)
-			}
-		} finally {
-			fairLock.release()
-		}
-
-		val response = chain.proceed(request)
-		if (response.networkResponse == null) {
-			synchronized(requestQueue) {
-				if (requestQueue.isEmpty() || timestamp < requestQueue.first()) return@synchronized
-				val iterator = requestQueue.iterator()
-				while (iterator.hasNext()) {
-					if (iterator.next() == timestamp) {
-						iterator.remove()
-						break
-					}
-				}
-				(requestQueue as Object).notifyAll()
-			}
-		}
-
-		return response
-	}
+	override val sortOrders = EnumSet.of(
+		SortOrder.NEWEST,
+		SortOrder.POPULARITY,
+	)
 
 	override suspend fun getListPage(
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
-		sortOrder: SortOrder
+		sortOrder: SortOrder,
 	): List<Manga> {
 		val url = buildString {
 			append("/library")
-			if(query.isNullOrEmpty()){
+			if (query.isNullOrEmpty()) {
 				append("?order_item=")
 				if (sortOrder == SortOrder.POPULARITY) {
 					append("likes_count")
@@ -148,7 +48,7 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 				append("&order_dir=desc")
 				append("&filter_by=title")
 				if (tags != null) {
-					for(tag in tags){
+					for (tag in tags) {
 						append("&genders[]=${tag.key}")
 					}
 				}
@@ -162,17 +62,15 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 		val doc = webClient.httpGet(url, headers).parseHtml()
 		val items = doc.body().select("div.element")
 		return items.mapNotNull { item ->
-			val href = item.selectFirst("a")?.attrAsRelativeUrlOrNull("href")?.substringAfter(' ') ?: return@mapNotNull null
+			val href =
+				item.selectFirst("a")?.attrAsRelativeUrlOrNull("href")?.substringAfter(' ') ?: return@mapNotNull null
 			Manga(
 				id = generateUid(href),
 				title = item.selectFirst("h4.text-truncate")?.text() ?: return@mapNotNull null,
 				coverUrl = item.select("style").toString().substringAfter("('").substringBeforeLast("')"),
 				altTitle = null,
 				author = null,
-				rating = item.selectFirst("span.score")
-					?.text()
-					?.toFloatOrNull()
-					?.div(10F) ?: RATING_UNKNOWN,
+				rating = item.selectFirst("span.score")?.text()?.toFloatOrNull()?.div(10F) ?: RATING_UNKNOWN,
 				url = href,
 				isNsfw = item.select("i").hasClass("fas fa-heartbeat fa-2x"),
 				tags = emptySet(),
@@ -192,7 +90,7 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 			largeCoverUrl = contents.selectFirst(".book-thumbnail")?.attrAsAbsoluteUrlOrNull("src"),
 			state = parseStatus(contents.select("span.book-status").text().orEmpty()),
 			author = contents.selectFirst("h5.card-title")?.attr("title")?.substringAfter(", "),
-			chapters = if(doc.select("div.chapters").isEmpty()){
+			chapters = if (doc.select("div.chapters").isEmpty()) {
 				doc.select(oneShotChapterListSelector()).mapChapters(reversed = true) { i, item ->
 					oneShotChapterFromElement(item)
 				}
@@ -204,14 +102,14 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 					scanelement.forEach { chapters.add(regularChapterFromElement(it, chaptername, i)) }
 				}
 				chapters
-			}
+			},
 		)
 	}
 
 	private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
+
 	private fun oneShotChapterFromElement(element: Element): MangaChapter {
-		val href = element.selectFirstOrThrow("div.row > .text-right > a")
-			.attrAsRelativeUrl("href")
+		val href = element.selectFirstOrThrow("div.row > .text-right > a").attrAsRelativeUrl("href")
 		return MangaChapter(
 			id = generateUid(href),
 			name = "One Shot",
@@ -225,9 +123,9 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 	}
 
 	private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
+
 	private fun regularChapterFromElement(element: Element, chName: String, number: Int): MangaChapter {
-		val href = element.selectFirstOrThrow("div.row > .text-right > a")
-			.attrAsRelativeUrl("href")
+		val href = element.selectFirstOrThrow("div.row > .text-right > a").attrAsRelativeUrl("href")
 		return MangaChapter(
 			id = generateUid(href),
 			name = chName,
@@ -255,7 +153,7 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 			doc = webClient.httpGet(newUrl, headers).parseHtml()
 		}
 
-		return doc.select("div.viewer-container img:not(noscript img)").map{
+		return doc.select("div.viewer-container img:not(noscript img)").map {
 			val href = if (it.hasAttr("data-src")) {
 				it.attr("abs:data-src")
 			} else {
@@ -274,23 +172,20 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 		val script1 = document.selectFirst("script:containsData(uniqid)")
 		val script2 = document.selectFirst("script:containsData(window.location.replace)")
 
-		val redirectHeaders = Headers.Builder()
-			.set("Referer", document.baseUri())
-			.build()
+		val redirectHeaders = Headers.Builder().set("Referer", document.baseUri()).build()
 
 		if (script1 != null) {
 			val data = script1.data()
-			val regexParams = """\{uniqid:'(.+)',cascade:(.+)\}""".toRegex()
+			val regexParams = """\{uniqid:'(.+)',cascade:(.+)}""".toRegex()
 			val regexAction = """form\.action\s?=\s?'(.+)'""".toRegex()
 			val params = regexParams.find(data)!!
-			val action = regexAction.find(data)!!.groupValues[1]
+			val action = regexAction.find(data)!!.groupValues[1].toHttpUrl()
 
-			val formBody = FormBody.Builder()
-				.add("uniqid", params.groupValues[1])
-				.add("cascade", params.groupValues[2])
-				.build()
-
-			return redirectToReadingPage(webClient.httpPost(action,redirectHeaders,formBody).parseHtml())
+			val formBody = mapOf(
+				"uniqid" to params.groupValues[1],
+				"cascade" to params.groupValues[2],
+			)
+			return redirectToReadingPage(webClient.httpPost(action, formBody, redirectHeaders).parseHtml())
 		}
 
 		if (script2 != null) {
@@ -311,7 +206,7 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 			MangaTag(
 				title = element.select("label").text(),
 				key = element.select("input").attr("value"),
-				source = source
+				source = source,
 			)
 		}
 	}
@@ -320,20 +215,5 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser (
 		status.contains("Publicándose") -> MangaState.ONGOING
 		status.contains("Finalizado") -> MangaState.FINISHED
 		else -> null
-	}
-
-	private suspend fun WebClient.httpPost(url: String, headers: Headers, body: FormBody): Response {
-		val client = context.httpClient
-		val request = Request.Builder()
-			.post(body)
-			.headers(headers)
-			.url(url)
-		return client.newCall(request.build()).await().ensureSuccess()
-	}
-
-	companion object {
-		private const val permits = 10
-		private const val period = 60L
-		private val unit = TimeUnit.SECONDS
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/ArabToons.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/ArabToons.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ARABTOONS", "Arab Toons", "ar")
+internal class ArabToons(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ARABTOONS, "arabtoons.net") {
+
+	override val isNsfwSource = true
+	override val datePattern = "dd-MM-yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Asq.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Asq.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ASQORG", "3Asq", "ar")
+internal class Asq(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ASQORG, "3asq.org") {
+
+	override val datePattern = "d MMMM، yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Azoranov.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Azoranov.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("AZORANOV", "Azoranov", "ar")
 internal class Azoranov(context: MangaLoaderContext) :
@@ -13,5 +12,4 @@ internal class Azoranov(context: MangaLoaderContext) :
 
 	override val tagPrefix = "novel-genre/"
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("ar", "AR")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/GateManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/GateManga.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("GATEMANGA", "Gate Manga", "ar")
 internal class GateManga(context: MangaLoaderContext) :
@@ -13,5 +12,4 @@ internal class GateManga(context: MangaLoaderContext) :
 
 	override val postreq = true
 	override val datePattern = "d MMMM، yyyy"
-	override val sourceLocale: Locale = Locale("ar", "AR")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLek.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLek.kt
@@ -7,7 +7,5 @@ import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 @MangaSourceParser("MANGALEK", "MangaLek", "ar")
-internal class MangaLek(context: MangaLoaderContext) : MadaraParser(
-	context, MangaSource.MANGALEK, "mangalek.com",
-	pageSize = 20,
-)
+internal class MangaLek(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGALEK, "mangalek.com", pageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLionz.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLionz.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGALIONZ", "Manga Lionz", "ar")
+internal class MangaLionz(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGALIONZ, "mangalionz.com", pageSize = 10) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaStarz.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaStarz.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGASTARZ", "Manga Starz", "ar")
+internal class MangaStarz(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGASTARZ, "mangastarz.com", pageSize = 10) {
+
+	override val datePattern = "d MMMM، yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Mangaspark.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Mangaspark.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGASPARK", "Mangaspark", "ar")
+internal class Mangaspark(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGASPARK, "mangaspark.com", pageSize = 10) {
+
+	override val postreq = true
+	override val datePattern = "d MMMM، yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Manhatic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Manhatic.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("MANHATIC", "Manhatic", "ar")
+internal class Manhatic(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANHATIC, "manhatic.com") {
+
+	override val isNsfwSource = true
+	override val datePattern = "MMMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/NijiTranslations.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/NijiTranslations.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("NIJITRANSLATIONS", "Niji Translations", "ar")
+internal class NijiTranslations(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.NIJITRANSLATIONS, "niji-translations.com") {
+
+	override val postreq = true
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Novelstown.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Novelstown.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("NOVELSTOWN", "Novelstown", "ar")
+internal class Novelstown(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.NOVELSTOWN, "novelstown.cyou") {
+
+	override val datePattern = "d MMMM، yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/WebtoonEmpire.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/WebtoonEmpire.kt
@@ -5,12 +5,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("WEBTOONEMPIRE", "Webtoon Empire", "ar")
 internal class WebtoonEmpire(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.WEBTOONEMPIRE, "webtoonempire.org", pageSize = 10) {
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale("ar", "AR")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ImmortalUpdates.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ImmortalUpdates.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("IMMORTALUPDATES", "Immortal Updates", "en")
+internal class ImmortalUpdates(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.IMMORTALUPDATES, "immortalupdates.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/IsekaiScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/IsekaiScan.kt
@@ -1,0 +1,165 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.jsoup.nodes.Document
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.host
+import org.koitharu.kotatsu.parsers.util.mapChapters
+import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
+import org.koitharu.kotatsu.parsers.util.parseFailed
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.removeSuffix
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.toTitleCase
+import org.koitharu.kotatsu.parsers.util.urlEncoded
+import java.text.SimpleDateFormat
+import java.util.EnumSet
+
+@MangaSourceParser("ISEKAISCAN", "Isekai Scan", "en")
+internal class IsekaiScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ISEKAISCAN, "isekaiscan.top", 16) {
+
+	override val tagPrefix = "mangas/"
+	override val datePattern = "MMMM d, HH:mm"
+
+	override val sortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.POPULARITY,
+		SortOrder.UPDATED,
+	)
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+
+					append("/?search=")
+					append(query.urlEncoded())
+					append("&page=")
+					append(pages.toString())
+					append("&post_type=wp-manga")
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/mangas/")
+					for (tag in tags) {
+						append(tag.key)
+					}
+
+					append("?orderby=2&page=")
+					append(pages.toString())
+
+				}
+
+				else -> {
+
+					if (sortOrder == SortOrder.POPULARITY) {
+						append("/popular-manga")
+					}
+					if (sortOrder == SortOrder.UPDATED) {
+						append("/latest-manga")
+					}
+					append("?page=")
+					append(pages.toString())
+				}
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+		return doc.select("div.row.c-tabs-item__content").ifEmpty {
+			doc.select("div.page-item-detail.manga")
+		}.map { div ->
+			val href = div.selectFirstOrThrow("a").attrAsRelativeUrl("href")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".item-summary")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.src().orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()?.trim()
+					?.lowercase()) {
+					"Ongoing" -> MangaState.ONGOING
+					"Completed " -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+
+	override suspend fun loadChapters(mangaUrl: String, document: Document): List<MangaChapter> {
+
+
+		val mangaId = document.select("div[id^=manga-chapters-holder]").attr("data-id")
+
+		val doc = webClient.httpGet("https://$domain/ajax-list-chapter?mangaID=$mangaId").parseHtml()
+
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
+
+		return doc.select(selectchapter).mapChapters(reversed = true) { i, li ->
+			val a = li.selectFirst("a")
+			val href = a?.attrAsRelativeUrlOrNull("href") ?: li.parseFailed("Link is missing")
+			val link = href + stylepage
+			MangaChapter(
+				id = generateUid(href),
+				url = link,
+				name = a.ownText(),
+				number = i + 1,
+				branch = null,
+				uploadDate = parseChapterDate(
+					dateFormat,
+					li.selectFirst(selectdate)?.text(),
+				),
+				scanlator = null,
+				source = source,
+			)
+		}
+	}
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val urlarray = doc.select("p#arraydata").text().split(",").toTypedArray()
+		return urlarray.map { url ->
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Itsyourightmanhua.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Itsyourightmanhua.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ITSYOURIGHTMANHUA", "Itsyourightmanhua", "en")
+internal class Itsyourightmanhua(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ITSYOURIGHTMANHUA, "itsyourightmanhua.com", 10) {
+
+	override val datePattern = "MMMM d, yyyy"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/KsGroupScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/KsGroupScans.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("KSGROUPSCANS", "Ks Group Scans", "en")
+internal class KsGroupScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KSGROUPSCANS, "ksgroupscans.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/KunManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/KunManga.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("KUNMANGA", "Kun Manga", "en")
+internal class KunManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KUNMANGA, "kunmanga.com", 10) {
+
+	override val datePattern = "MMMM d, yyyy"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LadyManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LadyManga.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LADYMANGA", "Lady Manga", "en")
+internal class LadyManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LADYMANGA, "ladymanga.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LilyManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LilyManga.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LILYMANGA", "LilyManga", "en")
+internal class LilyManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LILYMANGA, "lilymanga.net") {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "ys-genre/"
+	override val datePattern = "yyyy-MM-dd"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LoliconMobi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LoliconMobi.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LOLICONMOBI", "LoliconMobi", "en")
+internal class LoliconMobi(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LOLICONMOBI, "lolicon.mobi") {
+
+	override val postreq = true
+	override val isNsfwSource = true
+	override val tagPrefix = "lolicon-genre/"
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LuxManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/LuxManga.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LUXMANGA", "LuxManga", "en")
+internal class LuxManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LUXMANGA, "luxmanga.net") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaAction.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaAction.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAACTION", "Manga Action", "en")
+internal class MangaAction(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAACTION, "mangaaction.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaGalaxy.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaGalaxy.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAGALAXY", "Manga Galaxy", "en")
+internal class MangaGalaxy(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAGALAXY, "mangagalaxy.me", 16) {
+
+	override val datePattern = "MM/dd/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangastic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangastic.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGASTIC", "Mangastic", "en")
+internal class Mangastic(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGASTIC, "mangastic.cc", 20) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ToonChill.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ToonChill.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("TOONCHILL", "Toon Chill", "en")
+internal class ToonChill(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TOONCHILL, "toonchill.com", 32) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ApollComics.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ApollComics.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("APOLL_COMICS", "Apoll Comics", "es")
 internal class ApollComics(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.APOLL_COMICS, "apollcomics.com", 10) {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Copypastescan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Copypastescan.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("COPYPASTESCAN", "Copypastescan", "es")
 internal class Copypastescan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.COPYPASTESCAN, "copypastescan.xyz", 10) {
 
 	override val datePattern = "d MMMM, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Daprob.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Daprob.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("DAPROB", "Daprob", "es")
 internal class Daprob(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.DAPROB, "daprob.com") {
 
 	override val datePattern = "d 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/DokkoManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/DokkoManga.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("DOKKOMANGA", "Dokko Manga", "es")
 internal class DokkoManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.DOKKOMANGA, "dokkomanga.com", 10) {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/EmperorScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/EmperorScan.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("EMPERORSCAN", "Emperor Scan", "es")
 internal class EmperorScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.EMPERORSCAN, "dokkomanga.com") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Eromiau.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Eromiau.kt
@@ -4,7 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("EROMIAU", "Eromiau", "es")
 internal class Eromiau(context: MangaLoaderContext) :
@@ -12,5 +11,4 @@ internal class Eromiau(context: MangaLoaderContext) :
 
 	override val isNsfwSource = true
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/HerenScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/HerenScan.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("HERENSCAN", "Heren Scan", "es")
 internal class HerenScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.HERENSCAN, "herenscan.com") {
 
 	override val datePattern = "d 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Infrafandub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Infrafandub.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("INFRAFANDUB", "infrafandub", "es")
+internal class Infrafandub(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.INFRAFANDUB, "infrafandub.xyz", 10) {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/MangaMundoDrama.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/MangaMundoDrama.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAMUNDODRAMA", "Manga Mundo Drama", "es")
+internal class MangaMundoDrama(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAMUNDODRAMA, "inmortalscan.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Mangapt.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Mangapt.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAPT", "Mangapt", "es")
+internal class Mangapt(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAPT, "mangapt.com") {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/MundoManhwa.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/MundoManhwa.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MUNDO_MANHWA", "Mundo Manhwa", "es")
 internal class MundoManhwa(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.MUNDO_MANHWA, "mundomanhwa.com", 10) {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("es")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/NoblesseTranslations.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/NoblesseTranslations.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("NOBLESSETRANSLATIONS", "Noblesse Translations", "es")
+internal class NoblesseTranslations(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.NOBLESSETRANSLATIONS, "www.noblessetranslations.com") {
+
+	override val datePattern = "d MMMM, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RagnarokScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RagnarokScan.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RAGNAROKSCAN", "Ragnarok Scan", "es")
+internal class RagnarokScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RAGNAROKSCAN, "ragnarokscan.com") {
+
+	override val stylepage = ""
+	override val tagPrefix = "genero/"
+	override val datePattern = "MMMM d, yyyy"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RagnarokScanlation.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RagnarokScanlation.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RAGNAROKSCANLATION", "Ragnarok Scanlation", "es")
+internal class RagnarokScanlation(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RAGNAROKSCANLATION, "ragnarokscanlation.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/SamuraiScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/SamuraiScan.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("SAMURAISCAN", "Samurai Scan", "es")
+internal class SamuraiScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.SAMURAISCAN, "samuraiscan.com", 10) {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Scambertraslator.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Scambertraslator.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("SCAMBERTRASLATOR", "Scambertraslator", "es")
+internal class Scambertraslator(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.SCAMBERTRASLATOR, "scambertraslator.com") {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/TecnoScann.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/TecnoScann.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("TECNOSCANN", "TecnoScann", "es")
+internal class TecnoScann(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TECNOSCANN, "tecnoscann.com", 24) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Vermanhwa.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Vermanhwa.kt
@@ -1,0 +1,128 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.host
+import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.removeSuffix
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.toTitleCase
+import org.koitharu.kotatsu.parsers.util.urlEncoded
+import java.util.EnumSet
+
+@MangaSourceParser("VERMANHWA", "Vermanhwa", "es")
+internal class Vermanhwa(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.VERMANHWA, "vermanhwa.es", 10) {
+
+	override val isNsfwSource = true
+	override val datePattern = "MMMM d, yyyy"
+
+	override val sortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.NEWEST,
+		SortOrder.ALPHABETICAL,
+		SortOrder.RATING,
+		SortOrder.POPULARITY,
+		SortOrder.UPDATED,
+
+
+		)
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+					append("/page/")
+					append(pages.toString())
+					append("/?s=")
+					append(query.urlEncoded())
+					append("&post_type=wp-manga")
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/manga-genre/")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("/page/")
+					append(pages.toString())
+				}
+
+				else -> {
+
+					append("/manga/")
+					append("/page/")
+					append(pages.toString())
+					append("?m_orderby=")
+					if (sortOrder == SortOrder.NEWEST) {
+						append("new-manga")
+					}
+					if (sortOrder == SortOrder.ALPHABETICAL) {
+						append("alphabet")
+					}
+					if (sortOrder == SortOrder.RATING) {
+						append("rating")
+					}
+					if (sortOrder == SortOrder.POPULARITY) {
+						append("views")
+					}
+					if (sortOrder == SortOrder.UPDATED) {
+						append("latest")
+					}
+
+				}
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+		return doc.select("div.row.c-tabs-item__content").ifEmpty {
+			doc.select("div.page-item-detail.manga")
+		}.map { div ->
+			val href = div.selectFirstOrThrow("a").attrAsRelativeUrl("href")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".item-summary")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.src().orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()?.trim()
+					?.lowercase()) {
+					"OnGoing" -> MangaState.ONGOING
+					"Completed" -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/AstralManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/AstralManga.kt
@@ -11,5 +11,4 @@ internal class AstralManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.ASTRALMANGA, "astral-manga.fr", pageSize = 12) {
 
 	override val datePattern = "dd/MM/yyyy"
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/FrScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/FrScan.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("FRSCAN", "FrScan", "fr")
 internal class FrScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.FRSCAN, "fr-scan.com") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiScantradVf.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiScantradVf.kt
@@ -1,20 +1,9 @@
 package org.koitharu.kotatsu.parsers.site.madara.fr
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaSource
-import org.koitharu.kotatsu.parsers.model.MangaState
-import org.koitharu.kotatsu.parsers.model.MangaTag
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import org.koitharu.kotatsu.parsers.util.domain
-import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
-import org.koitharu.kotatsu.parsers.util.parseHtml
-import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
-import org.koitharu.kotatsu.parsers.util.toTitleCase
-import java.util.Locale
 
 @MangaSourceParser("HENTAISCANTRADVF", "Hentai-Scantrad", "fr")
 internal class HentaiScantradVf(context: MangaLoaderContext) :
@@ -22,42 +11,4 @@ internal class HentaiScantradVf(context: MangaLoaderContext) :
 
 	override val isNsfwSource = true
 	override val datePattern = "d MMMM, yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
-
-	override suspend fun getDetails(manga: Manga): Manga = coroutineScope {
-		val fullUrl = manga.url.toAbsoluteUrl(domain)
-		val doc = webClient.httpGet(fullUrl).parseHtml()
-
-		val chaptersDeferred = async { loadChapters(manga.url, doc) }
-
-		val stateselect = doc.body().select("div.summary-content").last()
-		val state =
-			stateselect?.let {
-				when (it.text()) {
-					in ongoing -> MangaState.ONGOING
-					in finished -> MangaState.FINISHED
-					else -> null
-				}
-			}
-
-		val desc = doc.body().selectFirst("div.description-summary div.summary__content")?.text()
-			?: doc.body() .selectFirst("div.datas_synopsis")?.text()
-
-		manga.copy(
-			tags = doc.body().select("div.genres-content a").mapNotNullToSet { a ->
-				MangaTag(
-					key = a.attr("href").removeSuffix("/").substringAfterLast('/'),
-					title = a.text().toTitleCase(),
-					source = source,
-				)
-			},
-			description = desc,
-			altTitle =
-			doc.body().select(".post-content_item:contains(Alt) .summary-content").firstOrNull()?.tableValue()?.text()
-				?.trim() ?: doc.body().select(".post-content_item:contains(Nomes alternativos: ) .summary-content")
-				.firstOrNull()?.tableValue()?.text()?.trim(),
-			state = state,
-			chapters = chaptersDeferred.await(),
-		)
-	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/Hentaizone.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/Hentaizone.kt
@@ -38,8 +38,8 @@ internal class Hentaizone(context: MangaLoaderContext) :
 			val href = a.attrAsRelativeUrl("href") + "?style=list"
 
 			// correct parse date missing a "."
-			val date_org = li.selectFirst("span.chapter-release-date i")?.text() ?: "janv 1, 2000"
-			val date_corect_parse = date_org
+			val dateOrg = li.selectFirst("span.chapter-release-date i")?.text() ?: "janv 1, 2000"
+			val dateCorrectParse = dateOrg
 				.replace("janv", "janv.")
 				.replace("févr", "févr.")
 				.replace("avr", "avr.")
@@ -56,7 +56,7 @@ internal class Hentaizone(context: MangaLoaderContext) :
 				branch = null,
 				uploadDate = parseChapterDate(
 					dateFormat,
-					date_corect_parse,
+					dateCorrectParse,
 				),
 				scanlator = null,
 				source = source,

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HhentaiFr.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HhentaiFr.kt
@@ -6,16 +6,12 @@ import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.domain
 import org.koitharu.kotatsu.parsers.util.insertCookies
-import java.util.Locale
-
 
 @MangaSourceParser("HHENTAIFR", "HhentaiFr", "fr")
 internal class HhentaiFr(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.HHENTAIFR, "hhentai.fr") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
-
 	override val isNsfwSource = true
 
 	init {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/KaratcamScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/KaratcamScans.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.fr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("KARATCAMSCANS", "Karatcam Scans", "fr")
+internal class KaratcamScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KARATCAMSCANS, "karatcam-scans.fr") {
+
+	override val tagPrefix = "webtoon-genre/"
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaHub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaHub.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.fr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAHUB", "Manga Hub", "fr")
+internal class MangaHub(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAHUB, "mangahub.fr") {
+
+	override val isNsfwSource = true
+	override val datePattern = "d MMMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaScantrad.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaScantrad.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANGA_SCANTRAD", "Manga Scantrad", "fr")
 internal class MangaScantrad(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.MANGA_SCANTRAD, "manga-scantrad.io") {
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaScantradUnofficial.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangaScantradUnofficial.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.fr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGASCANTRADUNOFFICIAL", "Manga Scantrad ( Unofficial )", "fr")
+internal class MangaScantradUnofficial(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGASCANTRADUNOFFICIAL, "www.mangascantrad.fr", 10) {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOrigines.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOrigines.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANGASORIGINES", "Mangas Origines", "fr")
 internal class MangasOrigines(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.MANGASORIGINES, "mangas-origines.fr") {
 
 	override val datePattern = "dd/MM/yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOriginesUnofficial.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOriginesUnofficial.kt
@@ -4,14 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANGASORIGINESUNOFFICIAL", "Mangas Origines ( unofficial )", "fr")
 internal class MangasOriginesUnofficial(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.MANGASORIGINESUNOFFICIAL, "mangas-origines.xyz") {
 
-
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/PantheonScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/PantheonScan.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("PANTHEONSCAN", "Pantheon Scan", "fr")
 internal class PantheonScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.PANTHEONSCAN, "pantheon-scan.com") {
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/RaijinScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/RaijinScans.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.fr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RAIJINSCANS", "Raijin Scans", "fr")
+internal class RaijinScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RAIJINSCANS, "raijinscans.fr") {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScanHentaiMenu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScanHentaiMenu.kt
@@ -4,7 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("SCANHENTAIMENU", "Scan Hentai Menu", "fr")
 internal class ScanHentaiMenu(context: MangaLoaderContext) :
@@ -12,5 +11,4 @@ internal class ScanHentaiMenu(context: MangaLoaderContext) :
 
 	override val isNsfwSource = true
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale.FRENCH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScantradVf.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScantradVf.kt
@@ -10,6 +10,5 @@ internal class ScantradVf(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.SCANTRADVF, "scantrad-vf.co") {
 
 	override val datePattern = "d MMMM yyyy"
-
 	override val tagPrefix = "genre/"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ToonFr.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ToonFr.kt
@@ -1,0 +1,63 @@
+package org.koitharu.kotatsu.parsers.site.madara.fr
+
+import org.jsoup.nodes.Document
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.mapChapters
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.removeSuffix
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import java.text.SimpleDateFormat
+
+@MangaSourceParser("TOONFR", "Toon Fr", "fr")
+internal class ToonFr(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TOONFR, "toonfr.com") {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "webtoon-genre/"
+	override val datePattern = "MMM d"
+
+	override suspend fun loadChapters(mangaUrl: String, document: Document): List<MangaChapter> {
+		val url = mangaUrl.toAbsoluteUrl(domain).removeSuffix('/') + "/ajax/chapters/"
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
+		val doc = webClient.httpPost(url, emptyMap()).parseHtml()
+
+		return doc.select("li.wp-manga-chapter").mapChapters(reversed = true) { i, li ->
+			val a = li.selectFirstOrThrow("a")
+			val href = a.attrAsRelativeUrl("href") + "?style=list"
+
+			// correct parse date missing a "."
+			val dateOrg = li.selectFirst("span.chapter-release-date i")?.text() ?: "janv 1, 2000"
+			val dateCorrectParse = dateOrg
+				.replace("Jan", "janv.")
+				.replace("Févr", "févr.")
+				.replace("Avr", "avr.")
+				.replace("Juil", "juil.")
+				.replace("Sept", "sept.")
+				.replace("Nov", "nov.")
+				.replace("Oct", "oct.")
+				.replace("Déc", "déc.")
+			MangaChapter(
+				id = generateUid(href),
+				url = href,
+				name = a.text(),
+				number = i + 1,
+				branch = null,
+				uploadDate = parseChapterDate(
+					dateFormat,
+					dateCorrectParse,
+				),
+				scanlator = null,
+				source = source,
+			)
+		}
+	}
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/KlikManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/KlikManga.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("KLIKMANGA", "Klik Manga", "id")
+internal class KlikManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KLIKMANGA, "klikmanga.id", 36) {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "genre/"
+	override val datePattern = "MMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Mgkomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Mgkomik.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("MGKOMIK", "Mgkomik", "id")
+internal class Mgkomik(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MGKOMIK, "mgkomik.com", 20) {
+
+	override val tagPrefix = "genres/"
+	override val datePattern = "dd MMM yy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/PojokManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/PojokManga.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("POJOKMANGA", "PojokManga", "id")
+internal class PojokManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.POJOKMANGA, "pojokmanga.net") {
+
+	override val tagPrefix = "komik-genre/"
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Shinigami.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Shinigami.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("SHINIGAMI", "Shinigami", "id")
+internal class Shinigami(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.SHINIGAMI, "shinigami.id", 10) {
+
+	override val tagPrefix = "genre/"
+	override val datePattern = "MMMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ko/RawDex.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ko/RawDex.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.ko
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("RAWDEX", "Raw Dex", "ko")
+internal class RawDex(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RAWDEX, "rawdex.net", 40) {
+
+	override val isNsfwSource = true
+	override val datePattern = "MMMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ArthurScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ArthurScan.kt
@@ -4,14 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("ARTHUR_SCAN", "Arthur Scan", "pt")
 internal class ArthurScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.ARTHUR_SCAN, "arthurscan.xyz") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atlantisscan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atlantisscan.kt
@@ -5,11 +5,9 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-
 @MangaSourceParser("ATLANTISSCAN", "Atlantisscan", "pt")
 internal class Atlantisscan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.ATLANTISSCAN, "br.atlantisscan.com", pageSize = 50) {
 
 	override val datePattern = "dd/MM/yyyy"
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Cabaredowatame.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Cabaredowatame.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-
 @MangaSourceParser("CABAREDOWATAME", "Dessert Scan", "pt")
 internal class Cabaredowatame(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.CABAREDOWATAME, "cabaredowatame.site", 10) {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/CafecomYaoi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/CafecomYaoi.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-
 @MangaSourceParser("CAFECOMYAOI", "Cafecom Yaoi", "pt")
 internal class CafecomYaoi(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.CAFECOMYAOI, "cafecomyaoi.com.br") {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/CeriseScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/CeriseScans.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("CERISE_SCANS", "Cerise Scans", "pt")
 internal class CeriseScans(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.CERISE_SCANS, "cerisescans.com") {
 
 	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/FinalScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/FinalScans.kt
@@ -4,14 +4,11 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("FINALSCANS", "Final Scans", "pt")
 internal class FinalScans(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.FINALSCANS, "finalscans.com") {
 
 	override val datePattern: String = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 	override val isNsfwSource = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/FoxWhite.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/FoxWhite.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("FOXWHITE", "Fox White", "pt")
 internal class FoxWhite(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.FOXWHITE, "foxwhite.com.br") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Gekkou.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Gekkou.kt
@@ -4,8 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("GEKKOU", "Gekkou", "pt")
 internal class Gekkou(context: MangaLoaderContext) :
@@ -13,5 +11,4 @@ internal class Gekkou(context: MangaLoaderContext) :
 
 	override val tagPrefix = "genero/"
 	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/GoofFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/GoofFansub.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-
 @MangaSourceParser("GOOFFANSUB", "Goof Fansub", "pt")
 internal class GoofFansub(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.GOOFFANSUB, "gooffansub.com") {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/HentaiGekkou.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/HentaiGekkou.kt
@@ -4,8 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("HENTAIGEKKOU", "Hentai Gekkou", "pt")
 internal class HentaiGekkou(context: MangaLoaderContext) :
@@ -13,6 +11,5 @@ internal class HentaiGekkou(context: MangaLoaderContext) :
 
 	override val tagPrefix = "genero/"
 	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 	override val isNsfwSource = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hentaiteca.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hentaiteca.kt
@@ -10,8 +10,6 @@ internal class Hentaiteca(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.HENTAITECA, "hentaiteca.net", pageSize = 10) {
 
 	override val datePattern = "MM/dd/yyyy"
-
 	override val tagPrefix = "genero/"
-
 	override val isNsfwSource = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hipercool.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hipercool.kt
@@ -5,15 +5,11 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-
 @MangaSourceParser("HIPERCOOL", "Hipercool", "pt")
 internal class Hipercool(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.HIPERCOOL, "hipercool.xyz", pageSize = 20) {
 
 	override val datePattern = "MMMM d, yyyy"
-
 	override val tagPrefix = "manga-tag/"
-
 	override val isNsfwSource = true
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/IllusionScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/IllusionScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ILLUSIONSCAN", "Illusion Scan", "pt")
+internal class IllusionScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ILLUSIONSCAN, "illusionscan.com") {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ImperioScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ImperioScans.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("IMPERIOSCANS", "Imperio Scans", "pt")
+internal class ImperioScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.IMPERIOSCANS, "imperioscans.com.br") {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/LeitorKamisama.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/LeitorKamisama.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LEITORKAMISAMA", "Leitor Kamisama", "pt")
+internal class LeitorKamisama(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LEITORKAMISAMA, "leitor.kamisama.com.br", 10) {
+
+	override val tagPrefix = "manga-tag/"
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/LerYaoi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/LerYaoi.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("LERYAOI", "LerYaoi", "pt")
+internal class LerYaoi(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LERYAOI, "leryaoi.com", 10) {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "genero/"
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/MomonohanaScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/MomonohanaScan.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MOMONOHANASCAN", "Momonohana Scan", "pt")
+internal class MomonohanaScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MOMONOHANASCAN, "momonohanascan.com", 10) {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/MoonLoversScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/MoonLoversScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MOONLOVERSSCAN", "Moon Lovers Scan", "pt")
+internal class MoonLoversScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MOONLOVERSSCAN, "moonloversscan.com.br", 10) {
+
+	override val isNsfwSource = true
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Moonwitchinlovescan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Moonwitchinlovescan.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MOONWITCHINLOVESCAN", "Moon Witchin Love Scan", "pt")
+internal class Moonwitchinlovescan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MOONWITCHINLOVESCAN, "moonwitchinlovescan.com", 10) {
+
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Nocsummer.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Nocsummer.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
-
 
 @MangaSourceParser("NOCSUMMER", "Nocturne Summer", "pt")
 internal class Nocsummer(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.NOCSUMMER, "nocsummer.com.br", 18) {
 
 	override val datePattern = "dd 'de' MMMMM 'de' yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/NoindexScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/NoindexScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("NOINDEXSCAN", "Noindex Scan", "pt")
+internal class NoindexScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.NOINDEXSCAN, "noindexscan.com") {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PeachScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PeachScan.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PEACHSCAN", "Peach Scan", "pt")
+internal class PeachScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PEACHSCAN, "www.peachscan.com", 10) {
+
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Pirulitorosa.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Pirulitorosa.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PIRULITOROSA", "Pirulitorosa", "pt")
+internal class Pirulitorosa(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PIRULITOROSA, "pirulitorosa.site") {
+
+	override val postreq = true
+	override val isNsfwSource = true
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PortalYaoi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PortalYaoi.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PORTALYAOI", "PortalYaoi", "pt")
+internal class PortalYaoi(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PORTALYAOI, "portalyaoi.com", 10) {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "genero/"
+	override val datePattern: String = "dd/MM"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Prismahentai.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Prismahentai.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("PRISMA_HENTAI", "Prisma hentai", "pt")
 internal class Prismahentai(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.PRISMA_HENTAI, "prismahentai.com", 18) {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("pt", "PT")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ProjetoScanlator.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ProjetoScanlator.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PROJETOSCANLATOR", "Projeto Scanlator", "pt")
+internal class ProjetoScanlator(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PROJETOSCANLATOR, "projetoscanlator.com", 10) {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Psunicorn.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Psunicorn.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PSUNICORN", "Psunicorn", "pt")
+internal class Psunicorn(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PSUNICORN, "psunicorn.com") {
+
+
+	override val isNsfwSource = true
+	override val datePattern: String = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RainbowFairyScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RainbowFairyScan.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RAINBOWFAIRYSCAN", "Rainbow Fairy Scan", "pt")
+internal class RainbowFairyScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RAINBOWFAIRYSCAN, "rainbowfairyscan.com", 10) {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RandomScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RandomScans.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RANDOMSCANS", "Random Scans", "pt")
+internal class RandomScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RANDOMSCANS, "randomscans.com") {
+
+	override val datePattern: String = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RogMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/RogMangas.kt
@@ -1,0 +1,13 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ROGMANGAS", "Rog Mangas", "pt")
+internal class RogMangas(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ROGMANGAS, "rogmangas.com", 51) {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/TankouHentai.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/TankouHentai.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("TANKOUHENTAI", "Tankou Hentai", "pt")
+internal class TankouHentai(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TANKOUHENTAI, "tankouhentai.com", pageSize = 16) {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/TheSugarScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/TheSugarScan.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("THESUGARSCAN", "The Sugar Scan", "pt")
+internal class TheSugarScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.THESUGARSCAN, "thesugarscan.com", pageSize = 15) {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd/MM/yyyy"
+
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ValkyrieScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ValkyrieScan.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("VALKYRIESCAN", "Valkyrie Scan", "pt")
+internal class ValkyrieScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.VALKYRIESCAN, "valkyriescan.com", pageSize = 10) {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/WinterScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/WinterScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("WINTERSCAN", "Winter Scan", "pt")
+internal class WinterScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.WINTERSCAN, "winterscan.com", pageSize = 20) {
+
+	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/WonderlandScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/WonderlandScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("WONDERLANDSCAN", "Wonderland Scan", "pt")
+internal class WonderlandScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.WONDERLANDSCAN, "wonderlandscan.com") {
+
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Yaoitoshokan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Yaoitoshokan.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("YAOITOSHOKAN", "Yaoitoshokan", "pt")
+internal class Yaoitoshokan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.YAOITOSHOKAN, "www.yaoitoshokan.net", 18) {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "genero/"
+	override val datePattern: String = "d MMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Ycscan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Ycscan.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("YCSCAN", "Ycscan", "pt")
+internal class Ycscan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.YCSCAN, "ycscan.com", 20) {
+
+	override val isNsfwSource = true
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YugenMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YugenMangas.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("YUGENMANGAS", "Yugen Mangas", "pt")
+internal class YugenMangas(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.YUGENMANGAS, "yugenmangas.com.br", 10) {
+
+	override val datePattern: String = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YuriLive.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YuriLive.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("YURILIVE", "Yuri Live", "pt")
+internal class YuriLive(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.YURILIVE, "yuri.live") {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "manga-genero/"
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ZeroScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ZeroScan.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ZEROSCAN", "Zero Scan", "pt")
+internal class ZeroScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ZEROSCAN, "zeroscan.com.br") {
+
+	override val postreq = true
+	override val datePattern: String = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/BestManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/BestManga.kt
@@ -7,7 +7,7 @@ import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 
-@MangaSourceParser("BEST_MANGA", "best manga", "ru")
+@MangaSourceParser("BEST_MANGA", "BestManga", "ru")
 internal class BestManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.BEST_MANGA, "bestmanga.club") {
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/MangaoneLove.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/MangaoneLove.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.ru
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("MANGAONELOVE", "MangaoneLove", "ru")
+internal class MangaoneLove(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAONELOVE, "mangaonelove.site", 10) {
+
+	override val datePattern = "dd.MM.yyyy"
+	override val postreq = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/MangaUptocats.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/MangaUptocats.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAUPTOCATS", "Manga Uptocats", "th")
+internal class MangaUptocats(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAUPTOCATS, "manga-uptocats.com") {
+
+
+	override val datePattern: String = "d MMMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Mangadeemak.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Mangadeemak.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGADEEMAK", "Mangadeemak", "th")
+internal class Mangadeemak(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGADEEMAK, "mangadeemak.com", 12) {
+
+
+	override val datePattern: String = "d MMMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/RhPlusManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/RhPlusManga.kt
@@ -1,0 +1,38 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.parseFailed
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.toRelativeUrl
+
+@MangaSourceParser("RHPLUSMANGA", "Rh2 Plus Manga", "th")
+internal class RhPlusManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RHPLUSMANGA, "www.rh2plusmanga.com") {
+
+	override val datePattern: String = "d MMMM yyyy"
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val root = doc.body().selectFirstOrThrow("div.main-col-inner").selectFirstOrThrow("div.reading-content")
+		return root.select("img").map { img ->
+			val url = img.src()?.toRelativeUrl(domain) ?: img.parseFailed("Image src not found")
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Anikiga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Anikiga.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 
 @MangaSourceParser("ANIKIGA", "Anikiga", "tr")
@@ -14,6 +13,5 @@ internal class Anikiga(context: MangaLoaderContext) :
 
 	override val tagPrefix = "manga-tur/"
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 	override val postreq = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/AnisaManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/AnisaManga.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 
 @MangaSourceParser("ANISA_MANGA", "Anisa Manga", "tr")
@@ -13,5 +12,4 @@ internal class AnisaManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.ANISA_MANGA, "anisamanga.com") {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/ArazNovel.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/ArazNovel.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 
 @MangaSourceParser("ARAZNOVEL", "Araz Novel", "tr")
@@ -13,6 +12,5 @@ internal class ArazNovel(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.ARAZNOVEL, "araznovel.com", 10) {
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 	override val postreq = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Cizgiromanarsivi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Cizgiromanarsivi.kt
@@ -1,0 +1,19 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("CIZGIROMANARSIVI", "Cizgiromanarsivi", "tr")
+internal class Cizgiromanarsivi(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.CIZGIROMANARSIVI, "cizgiromanarsivi.com", 24) {
+
+	override val stylepage = ""
+	override val tagPrefix = "kategori/"
+	override val datePattern = "dd.MM.yyyy"
+
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/DiamondFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/DiamondFansub.kt
@@ -5,7 +5,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 
 @MangaSourceParser("DIAMONDFANSUB", "Diamond Fansub", "tr")
@@ -13,6 +12,5 @@ internal class DiamondFansub(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.DIAMONDFANSUB, "diamondfansub.com", 10) {
 
 	override val datePattern = "d MMMM"
-	override val sourceLocale: Locale = Locale("tr")
 	override val tagPrefix = "seri-turu/"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/GloryManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/GloryManga.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("GLORYMANGA", "Glory Manga", "tr")
 internal class GloryManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.GLORYMANGA, "glorymanga.com", 18) {
 
 	override val datePattern = "dd/MM/yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/GuncelManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/GuncelManga.kt
@@ -4,12 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("GUNCEL_MANGA", "Guncel Manga", "tr")
 internal class GuncelManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.GUNCEL_MANGA, "guncelmanga.net") {
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Hayalistic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Hayalistic.kt
@@ -7,7 +7,7 @@ import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 
-@MangaSourceParser("HAYALISTIC", "Hayalistic", "vi")
+@MangaSourceParser("HAYALISTIC", "Hayalistic", "tr")
 internal class Hayalistic(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.HAYALISTIC, "hayalistic.com", 24) {
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Jiangzaitoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Jiangzaitoon.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("JIANGZAITOON", "Jiangzaitoon", "tr")
+internal class Jiangzaitoon(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.JIANGZAITOON, "jiangzaitoon.co") {
+
+	override val postreq = true
+	override val isNsfwSource = true
+	override val datePattern = "dd MMMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/MangaDiyari.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/MangaDiyari.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("MANGADIYARI", "MangaDiyari", "tr")
+internal class MangaDiyari(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGADIYARI, "manga-diyari.com", 10) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangabilgini.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangabilgini.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("MANGABILGINI", "Mangabilgini", "tr")
+internal class Mangabilgini(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGABILGINI, "mangabilgini.com", 44) {
+
+	override val selectdesc = "div.ozet__icerik"
+	override val postreq = true
+	override val datePattern = "d MMMM yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangakeyfi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangakeyfi.kt
@@ -4,7 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANGAKEYFI", "Mangakeyfi", "tr")
 internal class Mangakeyfi(context: MangaLoaderContext) :
@@ -12,6 +11,5 @@ internal class Mangakeyfi(context: MangaLoaderContext) :
 	override val tagPrefix = "mangalar-genre/"
 
 	override val datePattern = "d MMMM yyyy"
-	override val sourceLocale: Locale = Locale("tr")
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangawt.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Mangawt.kt
@@ -5,11 +5,9 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANGAWT", "Mangawt", "tr")
 internal class Mangawt(context: MangaLoaderContext) : MadaraParser(context, MangaSource.MANGAWT, "mangawt.com") {
-	override val datePattern = "MMMM d, yyyy"
 
-	override val sourceLocale: Locale = Locale("tr")
+	override val datePattern = "MMMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Manwe.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Manwe.kt
@@ -4,13 +4,10 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("MANWE", "Manwe", "tr")
 internal class Manwe(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.MANWE, "manwe.pro", 20) {
 
 	override val datePattern = "MMMM d, yyyy"
-	override val sourceLocale: Locale = Locale("tr")
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RomantikManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RomantikManga.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("ROMANTIKMANGA", "Romantik Manga", "tr")
+internal class RomantikManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ROMANTIKMANGA, "romantikmanga.com", 20) {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RuyaManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RuyaManga.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("RUYAMANGA", "Ruya Manga", "tr")
+internal class RuyaManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RUYAMANGA, "www.ruyamanga.com", 18) {
+
+	override val tagPrefix = "manga-kategori/"
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Timenaight.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Timenaight.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("TIMENAIGHT", "Timenaight", "tr")
+internal class Timenaight(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TIMENAIGHT, "timenaight.com") {
+
+	override val postreq = true
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Tonizutoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Tonizutoon.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("TONIZUTOON", "Tonizutoon", "tr")
+internal class Tonizutoon(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TONIZUTOON, "tonizutoon.com") {
+
+	override val isNsfwSource = true
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/TortugaCeviri.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/TortugaCeviri.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("TORTUGACEVIRI", "Tortuga Ceviri", "tr")
+internal class TortugaCeviri(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TORTUGACEVIRI, "tortuga-ceviri.com") {
+
+	override val datePattern = "MMMM d, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Webtoonhatti.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Webtoonhatti.kt
@@ -4,7 +4,6 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import java.util.Locale
 
 @MangaSourceParser("WEBTOONHATTI", "Webtoonhatti", "tr")
 internal class Webtoonhatti(context: MangaLoaderContext) :
@@ -12,6 +11,4 @@ internal class Webtoonhatti(context: MangaLoaderContext) :
 	override val tagPrefix = "webtoon-tur/"
 
 	override val datePattern = "d MMMM"
-	override val sourceLocale: Locale = Locale("tr")
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Webtoontr.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Webtoontr.kt
@@ -9,6 +9,7 @@ import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 @MangaSourceParser("WEBTOONTR", "Webtoontr", "tr")
 internal class Webtoontr(context: MangaLoaderContext) :
 	MadaraParser(context, MangaSource.WEBTOONTR, "webtoon-tr.com", 16) {
+
 	override val tagPrefix = "webtoon-kategori/"
 	override val datePattern = "dd/MM/yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/zh/Bakamh.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/zh/Bakamh.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.zh
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("BAKAMH", "Bakamh", "zh")
+internal class Bakamh(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.BAKAMH, "bakamh.com") {
+
+	override val datePattern = "YYYY 年 M 月 d 日"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/MangaReaderParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/MangaReaderParser.kt
@@ -115,14 +115,15 @@ internal abstract class MangaReaderParser(
 
 		val mangaState = state?.let {
 			when (it.text()) {
-				"مستمرة", "En curso", "Ongoing", "On going",
-				"Ativo", "En Cours", "OnGoing", "Đang tiến hành", "em lançamento", "Онгоінг", "Publishing",
-				"Devam Ediyor", "Em Andamento", "In Corso", "Güncel", "Berjalan", "Продолжается", "Updating",
-				"Lançando", "In Arrivo", "Emision", "En emision", "مستمر", "Curso", "En marcha", "Publicandose", "连载中",
+				"مستمرة", "En curso", "En Curso", "Ongoing", "OnGoing", "On going", "Ativo", "En Cours", "En cours",
+				"En cours \uD83D\uDFE2", "En cours de publication", "Đang tiến hành", "Em lançamento", "em lançamento", "Em Lançamento",
+				"Онгоінг", "Publishing", "Devam Ediyor", "Em Andamento", "In Corso", "Güncel", "Berjalan", "Продолжается", "Updating",
+				"Lançando", "In Arrivo", "Emision", "En emision", "مستمر", "Curso", "En marcha", "Publicandose", "Publicando", "连载中",
+				"Devam ediyor",
 				-> MangaState.ONGOING
 
-				"Completed", "Completo", "Complété", "Fini", "Terminé", "Tamamlandı", "Đã hoàn thành", "مكتملة", "Завершено",
-				"Finished", "Finalizado", "Completata", "One-Shot", "Bitti", "Tamat", "Completado", "Concluído", "Concluido", "已完结",
+				"Completed", "Completo", "Complété", "Fini", "Achevé", "Terminé", "Terminé ⚫", "Tamamlandı", "Đã hoàn thành", "Hoàn Thành", "مكتملة",
+				"Завершено", "Finished", "Finalizado", "Completata", "One-Shot", "Bitti", "Tamat", "Completado", "Concluído", "Concluido", "已完结", "Bitmiş",
 				-> MangaState.FINISHED
 
 				else -> null
@@ -141,8 +142,7 @@ internal abstract class MangaReaderParser(
 				|| docs.selectFirst(".postbody .alr") != null
 
 		return manga.copy(
-			description = tablemode?.selectFirst("div.entry-content")?.html() ?: docs.selectFirst("div.entry-content")
-				?.html(),
+			description = docs.selectFirst("div.entry-content")?.text(),
 			state = mangaState,
 			author = author,
 			isNsfw = manga.isNsfw || nsfw,

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/LegionScansEn.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/LegionScansEn.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.en
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+
+
+@MangaSourceParser("LEGIONSCANS_EN", "Legion Scans EN", "en")
+internal class LegionScansEn(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.LEGIONSCANS_EN, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("legionscans.com")
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/LegionScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/LegionScans.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+
+@MangaSourceParser("LEGIONSCANS", "Legion Scans", "es")
+internal class LegionScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.LEGIONSCANS, pageSize = 20, searchPageSize = 20) {
+
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("legionscans.com")
+
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/VfScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/VfScan.kt
@@ -1,0 +1,18 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.fr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("VFSCAN", "Vf Scan", "fr")
+internal class VfScan(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.VFSCAN, pageSize = 18, searchPageSize = 18) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("www.vfscan.com")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.FRENCH)
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/AinzScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/AinzScans.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+
+
+@MangaSourceParser("AINZSCANS", "Ainz Scans", "id")
+internal class AinzScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.AINZSCANS, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("ainzscans.site")
+
+	override val listUrl = "/series"
+}

--- a/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaSources.kt
+++ b/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaSources.kt
@@ -3,5 +3,5 @@ package org.koitharu.kotatsu.parsers
 import org.junit.jupiter.params.provider.EnumSource
 import org.koitharu.kotatsu.parsers.model.MangaSource
 
-@EnumSource(MangaSource::class, names = ["LOCAL", "DUMMY"], mode = EnumSource.Mode.EXCLUDE)
+@EnumSource(MangaSource::class, names = ["TUMANGAONLINE"], mode = EnumSource.Mode.INCLUDE)
 internal annotation class MangaSources


### PR DESCRIPTION
Tested in main app with DummyParser

Some clarifications:

- Users will need to enable the option to ignore SSL errors because the host used to display images has a misconfigured certificate.
- This site needs a rate limit to avoid 429 errors and IP bans. Since there is currently no easy option to configure this, the RateLimit is an interceptor (ported from Tachiyomi).
- Since there is still no httpPost method that allows sending headers, I created a new client for the request. Otherwise, the site won't redirect properly.