### PR TITLE
add source and fix

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/BatoToParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/BatoToParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import androidx.collection.ArraySet
 import org.json.JSONArray

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/ComickFunParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/ComickFunParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import androidx.collection.ArraySet
 import androidx.collection.SparseArrayCompat

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/ExHentaiParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/ExHentaiParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import androidx.collection.SparseArrayCompat
 import androidx.collection.set

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/NHentaiParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/NHentaiParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import androidx.collection.ArraySet
 import kotlinx.coroutines.async

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/NineMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/NineMangaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.all
 
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.be
 
 import androidx.collection.ArraySet
 import org.json.JSONArray

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/CloneMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/CloneMangaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.en
 
 import org.koitharu.kotatsu.parsers.InternalParsersApi
 import org.koitharu.kotatsu.parsers.MangaLoaderContext

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/MangaTownParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/MangaTownParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaParser

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/Manhwa18Parser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/Manhwa18Parser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.en
 
 import androidx.collection.ArrayMap
 import org.koitharu.kotatsu.parsers.MangaLoaderContext

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/es/TuMangaOnlineParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/es/TuMangaOnlineParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.es
 
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.fr
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -10,32 +10,9 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.PagedMangaParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.exception.ParseException
-import org.koitharu.kotatsu.parsers.model.Manga
-import org.koitharu.kotatsu.parsers.model.MangaChapter
-import org.koitharu.kotatsu.parsers.model.MangaPage
-import org.koitharu.kotatsu.parsers.model.MangaSource
-import org.koitharu.kotatsu.parsers.model.MangaState
-import org.koitharu.kotatsu.parsers.model.MangaTag
-import org.koitharu.kotatsu.parsers.model.RATING_UNKNOWN
-import org.koitharu.kotatsu.parsers.model.SortOrder
-import org.koitharu.kotatsu.parsers.util.assertNotNull
-import org.koitharu.kotatsu.parsers.util.attrAsAbsoluteUrlOrNull
-import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
-import org.koitharu.kotatsu.parsers.util.concatUrl
-import org.koitharu.kotatsu.parsers.util.domain
-import org.koitharu.kotatsu.parsers.util.flattenTo
-import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.model.*
+import org.koitharu.kotatsu.parsers.util.*
 import org.koitharu.kotatsu.parsers.util.json.getIntOrDefault
-import org.koitharu.kotatsu.parsers.util.mapToSet
-import org.koitharu.kotatsu.parsers.util.ownTextOrNull
-import org.koitharu.kotatsu.parsers.util.parseHtml
-import org.koitharu.kotatsu.parsers.util.parseJson
-import org.koitharu.kotatsu.parsers.util.requireElementById
-import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
-import org.koitharu.kotatsu.parsers.util.textOrNull
-import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
-import org.koitharu.kotatsu.parsers.util.toTitleCase
-import org.koitharu.kotatsu.parsers.util.urlBuilder
 import java.util.Calendar
 import java.util.EnumSet
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/JapScanParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/JapScanParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.fr
 
 import okhttp3.Headers
 import org.json.JSONObject

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/ScantradUnion.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/ScantradUnion.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.fr
 
 import okhttp3.Headers
 import org.koitharu.kotatsu.parsers.MangaLoaderContext

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/DoujinDesuParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/DoujinDesuParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ja/NicovideoSeigaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ja/NicovideoSeigaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.ja
 
 import org.koitharu.kotatsu.parsers.InternalParsersApi
 import org.koitharu.kotatsu.parsers.MangaLoaderContext

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/FalconManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/FalconManga.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("FALCONMANGA", "FalconManga", "ar")
+internal class FalconManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.FALCONMANGA, "falconmanga.com") {
+
+	override val datePattern = "d MMMM، yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/KolManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/KolManga.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("KOLMANGA", "KolManga", "ar")
+internal class KolManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KOLMANGA, "kolmanga.com")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLeks.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/MangaLeks.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGALEKS", "MangaLeks", "ar")
+internal class MangaLeks(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGALEKS, "mangaleks.com") {
+
+	override val datePattern = "yyyy/MM/dd"
+	override val postreq = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ArcaneScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ArcaneScans.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("ARCANESCANS", "ArcaneScans", "en")
+internal class ArcaneScans(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.ARCANESCANS, "arcanescans.com", 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Comiz.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Comiz.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("COMIZ", "Comiz", "en")
+internal class Comiz(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.COMIZ, "v2.comiz.net", 10) {
+
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/DuckManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/DuckManga.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("DUCKMANGA", "DuckManga", "en")
+internal class DuckManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.DUCKMANGA, "duckmanga.com", 20) {
+
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Grabber.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Grabber.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("GRABBER", "Grabber", "en")
+internal class Grabber(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.GRABBER, "grabber.zone", 20) {
+
+	override val tagPrefix = "type/"
+	override val datePattern = "dd.MM.yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai3z.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai3z.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("HENTAI3Z", "Hentai3z", "en")
+internal class Hentai3z(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.HENTAI3Z, "hentai3z.xyz", pageSize = 20) {
+
+	override val isNsfwSource = true
+	override val withoutAjax = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentaixdickgirl.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentaixdickgirl.kt
@@ -1,0 +1,49 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.jsoup.nodes.Document
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.mapChapters
+import org.koitharu.kotatsu.parsers.util.parseFailed
+import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
+import java.text.SimpleDateFormat
+
+@MangaSourceParser("HENTAIXDICKGIRL", "Hentaixdickgirl", "en")
+internal class Hentaixdickgirl(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.HENTAIXDICKGIRL, "hentaixdickgirl.com", 16) {
+
+	override val isNsfwSource = true
+	override val postreq = true
+
+	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
+		val root2 = doc.body().selectFirstOrThrow("div.listing-chapters_wrap")
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
+		return root2.select(selectchapter).mapChapters(reversed = true) { i, li ->
+			val a = li.selectFirst("a")
+			val href = a?.attrAsRelativeUrlOrNull("href") ?: li.parseFailed("Link is missing")
+			val link = href + stylepage
+			val dateText = li.selectFirst("a.c-new-tag")?.attr("title") ?: li.selectFirst(selectdate)?.text()
+			val name = a.selectFirst("p")?.text() ?: a.ownText()
+			MangaChapter(
+				id = generateUid(href),
+				name = name,
+				number = i + 1,
+				url = link,
+				uploadDate = parseChapterDate(
+					dateFormat,
+					dateText,
+				),
+				source = source,
+				scanlator = null,
+				branch = null,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/JiManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/JiManga.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("JIMANGA", "JiManga", "en")
+internal class JiManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.JIMANGA, "jimanga.com")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDass.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDass.kt
@@ -1,0 +1,202 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.jsoup.nodes.Document
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.*
+import java.text.SimpleDateFormat
+
+@MangaSourceParser("MANGADASS", "MangaDass", "en")
+internal class MangaDass(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGADASS, "mangadass.com", 20) {
+
+	override val isNsfwSource = true
+	override val datePattern = "dd MMM yyyy"
+	override val withoutAjax = true
+	override val selectchapter = "li.a-h"
+	override val selectdesc = "div.ss-manga"
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+
+					append("/?s=")
+					append(query.urlEncoded())
+					append("&page=")
+					append(pages.toString())
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/$tagPrefix")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("/")
+					append(pages.toString())
+					append("?")
+				}
+
+				else -> {
+
+					append("/$listeurl")
+					append("/")
+					append(pages.toString())
+					append("?")
+				}
+			}
+			append("orderby=")
+			when (sortOrder) {
+				SortOrder.POPULARITY -> append("views")
+				SortOrder.UPDATED -> append("latest")
+				SortOrder.NEWEST -> append("new-manga")
+				SortOrder.ALPHABETICAL -> append("alphabet")
+				else -> append("latest")
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+
+
+		return doc.select("div.row.c-tabs-item__content").ifEmpty {
+			doc.select("div.page-item-detail")
+		}.map { div ->
+			val href = div.selectFirst("a")?.attrAsRelativeUrlOrNull("href") ?: div.parseFailed("Link not found")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".item-summary")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.src().orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()
+					?.lowercase()) {
+					in ongoing -> MangaState.ONGOING
+					in finished -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+
+	override suspend fun getDetails(manga: Manga): Manga = coroutineScope {
+		val fullUrl = manga.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val body = doc.body()
+
+		val chaptersDeferred = async { getChapters(manga, doc) }
+
+		val desc = body.select(selectdesc).let {
+			if (it.select("p").text().isNotEmpty()) {
+				it.select("p").joinToString(separator = "\n\n") { p ->
+					p.text().replace("<br>", "\n")
+				}
+			} else {
+				it.text()
+			}
+		}
+
+		val stateDiv = (body.selectFirst("div.post-content_item:contains(Status)"))?.selectLast("div.summary-content")
+
+		val state = stateDiv?.let {
+			when (it.text()) {
+				in ongoing -> MangaState.ONGOING
+				in finished -> MangaState.FINISHED
+				else -> null
+			}
+		}
+
+		val alt =
+			doc.body().select(".post-content_item:contains(Alt) .summary-content").firstOrNull()?.tableValue()?.text()
+				?.trim() ?: doc.body().select(".post-content_item:contains(Nomes alternativos: ) .summary-content")
+				.firstOrNull()?.tableValue()?.text()?.trim()
+
+		manga.copy(
+			tags = doc.body().select(selectgenre).mapNotNullToSet { a ->
+				MangaTag(
+					key = a.attr("href").removeSuffix("/").substringAfterLast('/'),
+					title = a.text().toTitleCase(),
+					source = source,
+				)
+			},
+			description = desc,
+			altTitle = alt,
+			state = state,
+			chapters = chaptersDeferred.await(),
+		)
+	}
+
+	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
+		val root2 = doc.body().selectFirstOrThrow("div.panel-manga-chapter")
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
+		return root2.select(selectchapter).mapChapters(reversed = true) { i, li ->
+			val a = li.selectFirst("a")
+			val href = a?.attrAsRelativeUrlOrNull("href") ?: li.parseFailed("Link is missing")
+			val link = href + stylepage
+			val dateText = li.selectFirst("a.c-new-tag")?.attr("title") ?: li.selectFirst(selectdate)?.text()
+			val name = a.selectFirst("p")?.text() ?: a.ownText()
+			MangaChapter(
+				id = generateUid(href),
+				name = name,
+				number = i + 1,
+				url = link,
+				uploadDate = parseChapterDate(
+					dateFormat,
+					dateText,
+				),
+				source = source,
+				scanlator = null,
+				branch = null,
+			)
+		}
+	}
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val root = doc.body().selectFirstOrThrow("div.read-manga").selectFirstOrThrow("div.read-content")
+		return root.select("img").map { img ->
+			val url = img.src()?.toRelativeUrl(domain) ?: img.parseFailed("Image src not found")
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDna.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDna.kt
@@ -1,0 +1,198 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.jsoup.nodes.Document
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.*
+import java.text.SimpleDateFormat
+
+@MangaSourceParser("MANGADNA", "MangaDna", "en")
+internal class MangaDna(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGADNA, "mangadna.com", 20) {
+
+	override val isNsfwSource = true
+	override val datePattern = "dd MMM yyyy"
+	override val withoutAjax = true
+	override val selectdesc = "div.dsct"
+	override val selectchapter = "li.a-h"
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+					append("/page/")
+					append(pages.toString())
+					append("/?s=")
+					append(query.urlEncoded())
+					append("&post_type=wp-manga&")
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/$tagPrefix")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("/page/")
+					append(pages.toString())
+					append("?")
+				}
+
+				else -> {
+
+					append("/$listeurl")
+					append("/page/")
+					append(pages.toString())
+					append("?")
+				}
+			}
+			append("m_orderby=")
+			when (sortOrder) {
+				SortOrder.POPULARITY -> append("views")
+				SortOrder.UPDATED -> append("latest")
+				SortOrder.NEWEST -> append("new-manga")
+				SortOrder.ALPHABETICAL -> append("alphabet")
+				else -> append("latest")
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+
+
+		return doc.select("div.home-item").map { div ->
+			val href = div.selectFirst("a")?.attrAsRelativeUrlOrNull("href") ?: div.parseFailed("Link not found")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".hcontent")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.src().orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("div.hitem-rate span")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()
+					?.lowercase()) {
+					in ongoing -> MangaState.ONGOING
+					in finished -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+
+	override suspend fun getDetails(manga: Manga): Manga = coroutineScope {
+		val fullUrl = manga.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val body = doc.body()
+
+		val chaptersDeferred = async { getChapters(manga, doc) }
+
+		val desc = body.select(selectdesc).let {
+			if (it.select("p").text().isNotEmpty()) {
+				it.select("p").joinToString(separator = "\n\n") { p ->
+					p.text().replace("<br>", "\n")
+				}
+			} else {
+				it.text()
+			}
+		}
+
+		val stateDiv = (body.selectFirst("div.post-content_item:contains(Status)"))?.selectLast("div.summary-content")
+
+		val state = stateDiv?.let {
+			when (it.text()) {
+				in ongoing -> MangaState.ONGOING
+				in finished -> MangaState.FINISHED
+				else -> null
+			}
+		}
+
+		val alt =
+			doc.body().select(".post-content_item:contains(Alt) .summary-content").firstOrNull()?.tableValue()?.text()
+				?.trim() ?: doc.body().select(".post-content_item:contains(Nomes alternativos: ) .summary-content")
+				.firstOrNull()?.tableValue()?.text()?.trim()
+
+		manga.copy(
+			tags = doc.body().select(selectgenre).mapNotNullToSet { a ->
+				MangaTag(
+					key = a.attr("href").removeSuffix("/").substringAfterLast('/'),
+					title = a.text().toTitleCase(),
+					source = source,
+				)
+			},
+			description = desc,
+			altTitle = alt,
+			state = state,
+			chapters = chaptersDeferred.await(),
+		)
+	}
+
+	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
+		val root2 = doc.body().selectFirstOrThrow("div.panel-manga-chapter")
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
+		return root2.select(selectchapter).mapChapters(reversed = true) { i, li ->
+			val a = li.selectFirst("a")
+			val href = a?.attrAsRelativeUrlOrNull("href") ?: li.parseFailed("Link is missing")
+			val link = href + stylepage
+			val dateText = li.selectFirst("a.c-new-tag")?.attr("title") ?: li.selectFirst(selectdate)?.text()
+			val name = a.selectFirst("p")?.text() ?: a.ownText()
+			MangaChapter(
+				id = generateUid(href),
+				name = name,
+				number = i + 1,
+				url = link,
+				uploadDate = parseChapterDate(
+					dateFormat,
+					dateText,
+				),
+				source = source,
+				scanlator = null,
+				branch = null,
+			)
+		}
+	}
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val root = doc.body().selectFirstOrThrow("div.read-manga").selectFirstOrThrow("div.read-content")
+		return root.select("img").map { img ->
+			val url = img.src()?.toRelativeUrl(domain) ?: img.parseFailed("Image src not found")
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaFastNet.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaFastNet.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAFASTNET", "Manga Fast Net", "en")
+internal class MangaFastNet(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAFASTNET, "manhuafast.net") {
+
+	override val withoutAjax = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangagoyaoi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangagoyaoi.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("MANGAGOYAOI", "Mangagoyaoi", "en")
+internal class Mangagoyaoi(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAGOYAOI, "mangagoyaoi.com") {
+
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhwaz.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhwaz.kt
@@ -1,0 +1,105 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.*
+
+@MangaSourceParser("MANHWAZ", "Manhwaz", "en")
+internal class Manhwaz(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANHWAZ, "manhwaz.com", 40) {
+
+	override val listeurl = "genre/manhwa"
+	override val tagPrefix = "genre/"
+	override val withoutAjax = true
+	override val selectTestAsync = "div.list-chapter"
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+
+					append("/search?s=")
+					append(query.urlEncoded())
+					append("&page=")
+					append(pages.toString())
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/$tagPrefix")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("?page=")
+					append(pages.toString())
+					append("&")
+				}
+
+				else -> {
+
+					append("/$listeurl")
+					append("?page=")
+					append(pages.toString())
+					append("&")
+				}
+			}
+			append("m_orderby=")
+			when (sortOrder) {
+				SortOrder.POPULARITY -> append("views")
+				SortOrder.UPDATED -> append("latest")
+				SortOrder.NEWEST -> append("new-manga")
+				SortOrder.ALPHABETICAL -> append("alphabet")
+				else -> append("latest")
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+
+		return doc.select("div.row.c-tabs-item__content").ifEmpty {
+			doc.select("div.page-item-detail")
+		}.map { div ->
+			val href = div.selectFirst("a")?.attrAsRelativeUrlOrNull("href") ?: div.parseFailed("Link not found")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".item-summary")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.src().orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()
+					?.lowercase()) {
+					in ongoing -> MangaState.ONGOING
+					in finished -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Paritehaber.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Paritehaber.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("PARITEHABER", "Paritehaber", "en")
+internal class Paritehaber(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.PARITEHABER, "www.paritehaber.com", 10) {
+
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Rio2MangaNet.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Rio2MangaNet.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("RIO2MANGANET", "Rio2MangaNet", "en")
+internal class Rio2MangaNet(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RIO2MANGANET, "rio2manga.net", 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ShibaManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ShibaManga.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("SHIBAMANGA", "Shiba Manga", "en")
+internal class ShibaManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.SHIBAMANGA, "shibamanga.com") {
+
+	override val datePattern = "MM/dd/yyyy"
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/WebComic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/WebComic.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.en
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("WEBCOMIC", "WebComic", "en")
+internal class WebComic(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.WEBCOMIC, "webcomic.me") {
+
+	override val postreq = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Cocorip.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Cocorip.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("COCORIP", "Cocorip", "es")
+internal class Cocorip(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.COCORIP, "cocorip.net", 16) {
+
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/DragonTranslationParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/DragonTranslationParser.kt
@@ -1,0 +1,88 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.host
+import org.koitharu.kotatsu.parsers.util.parseFailed
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.urlEncoded
+import java.util.EnumSet
+
+@MangaSourceParser("DRAGONTRANSLATION", "DragonTranslation", "es")
+internal class DragonTranslationParser(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.DRAGONTRANSLATION, "dragontranslation.net", 30) {
+
+	override val sortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.UPDATED,
+	)
+
+	override val selectPage = "div#chapter_imgs img"
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+					append("/mangas?buscar=")
+					append(query.urlEncoded())
+					append("&page=")
+					append(pages.toString())
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/mangas?tag=")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("&page=")
+					append(pages.toString())
+				}
+
+				else -> {
+
+					append("/mangas")
+					append("?page=")
+					append(pages.toString())
+				}
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+
+		return doc.select("div.video-bg div.col-6 ").map { div ->
+			val href =
+				div.selectFirst("a.series-link")?.attrAsRelativeUrlOrNull("href") ?: div.parseFailed("Link not found")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img.thumb-img")?.src().orEmpty(),
+				title = div.selectFirst("div.series-box h5")?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = emptySet(),
+				author = null,
+				state = null,
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/KoinoboriScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/KoinoboriScan.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("KOINOBORISCAN", "Koinobori Scan", "es")
+internal class KoinoboriScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KOINOBORISCAN, "koinoboriscan.com") {
+
+	override val postreq = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Lectorunitoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Lectorunitoon.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("LECTORUNITOON", "Lectorunitoon", "es")
+internal class Lectorunitoon(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.LECTORUNITOON, "lectorunitoon.com", 10) {
+
+	override val tagPrefix = "generos/"
+	override val datePattern = "dd/MM/yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RightdarkScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/RightdarkScan.kt
@@ -1,0 +1,11 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("RIGHTDARKSCAN", "Rightdark Scan", "es")
+internal class RightdarkScan(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.RIGHTDARKSCAN, "rightdark-scan.com", 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/TraduccionesMoonlight.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/TraduccionesMoonlight.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("TRADUCCIONESMOONLIGHT", "Traducciones Moonlight", "es")
+internal class TraduccionesMoonlight(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.TRADUCCIONESMOONLIGHT, "traduccionesmoonlight.com") {
+
+	override val datePattern = "d MMMM, yyyy"
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Indo18h.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Indo18h.kt
@@ -1,0 +1,14 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+@MangaSourceParser("INDO18H", "Indo18h", "id")
+internal class Indo18h(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.INDO18H, "indo18h.com", 24) {
+
+	override val isNsfwSource = true
+	override val withoutAjax = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/ManhwaPlus.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/ManhwaPlus.kt
@@ -1,0 +1,103 @@
+package org.koitharu.kotatsu.parsers.site.madara.id
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.model.MangaState
+import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.*
+import java.util.Locale
+
+@MangaSourceParser("MANHWAPLUS", "Manhwa Plus", "id")
+internal class ManhwaPlus(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANHWAPLUS, "manhwaplus.pro", 10) {
+
+	override val isNsfwSource = true
+	override val tagPrefix = "genre/"
+	override val datePattern = "MMMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+	override val withoutAjax = true
+	override val listeurl = "series/"
+
+	override suspend fun getListPage(
+		page: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
+
+		val url = buildString {
+			append("https://")
+			append(domain)
+			val pages = page + 1
+
+			when {
+				!query.isNullOrEmpty() -> {
+					append("/page/")
+					append(pages.toString())
+					append("/?s=")
+					append(query.urlEncoded())
+					append("&post_type=wp-manga&")
+				}
+
+				!tags.isNullOrEmpty() -> {
+					append("/$tagPrefix")
+					for (tag in tags) {
+						append(tag.key)
+					}
+					append("/page/")
+					append(pages.toString())
+					append("?")
+				}
+
+				else -> {
+
+					append("/$listeurl")
+					append("/page/")
+					append(pages.toString())
+					append("?")
+				}
+			}
+		}
+		val doc = webClient.httpGet(url).parseHtml()
+
+		return doc.select("div.row.c-tabs-item__content").ifEmpty {
+			doc.select("div.page-item-detail")
+		}.map { div ->
+			val href = div.selectFirst("a")?.attrAsRelativeUrlOrNull("href") ?: div.parseFailed("Link not found")
+			val summary = div.selectFirst(".tab-summary") ?: div.selectFirst(".item-summary")
+			Manga(
+				id = generateUid(href),
+				url = href,
+				publicUrl = href.toAbsoluteUrl(div.host ?: domain),
+				coverUrl = div.selectFirst("img")?.attr("data-wpfc-original-src") ?: div.selectFirst("img")?.src()
+					.orEmpty(),
+				title = (summary?.selectFirst("h3") ?: summary?.selectFirst("h4")
+				?: div.selectFirst("h5.series-title"))?.text().orEmpty(),
+				altTitle = null,
+				rating = div.selectFirst("span.total_votes")?.ownText()?.toFloatOrNull()?.div(5f) ?: -1f,
+				tags = summary?.selectFirst(".mg_genres")?.select("a")?.mapNotNullToSet { a ->
+					MangaTag(
+						key = a.attr("href").removeSuffix('/').substringAfterLast('/'),
+						title = a.text().ifEmpty { return@mapNotNullToSet null }.toTitleCase(),
+						source = source,
+					)
+				}.orEmpty(),
+				author = summary?.selectFirst(".mg_author")?.selectFirst("a")?.ownText(),
+				state = when (summary?.selectFirst(".mg_status")?.selectFirst(".summary-content")?.ownText()
+					?.lowercase()) {
+					in ongoing -> MangaState.ONGOING
+					in finished -> MangaState.FINISHED
+					else -> null
+				},
+				source = source,
+				isNsfw = isNsfwSource,
+			)
+		}
+	}
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/Mangazavr.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ru/Mangazavr.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.ru
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("MANGAZAVR", "Mangazavr", "ru")
+internal class Mangazavr(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAZAVR, "mangazavr.ru") {
+
+	override val datePattern = "dd.MM.yyyy"
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuabug.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuabug.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("MANHUABUG", "Manhuabug", "th")
+internal class Manhuabug(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANHUABUG, "www.manhuabug.com", 10) {
+
+	override val datePattern: String = "d MMMM yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuakey.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuakey.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.pt
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.Locale
+
+@MangaSourceParser("MANHUAKEY", "Manhuakey", "th")
+internal class Manhuakey(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANHUAKEY, "www.manhuakey.com", 10) {
+
+	override val datePattern: String = "d MMMM yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/KuroiManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/KuroiManga.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("KUROIMANGA", "Kuroi Manga", "tr")
+internal class KuroiManga(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.KUROIMANGA, "www.kuroimanga.com") {
+
+	override val datePattern = "d MMMM yyyy"
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/NiveraFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/NiveraFansub.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("NIVERAFANSUB", "Nivera Fansub", "tr")
+internal class NiveraFansub(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.NIVERAFANSUB, "niverafansub.com") {
+
+	override val datePattern = "d MMMM yyyy"
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/ViyaFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/ViyaFansub.kt
@@ -1,0 +1,16 @@
+package org.koitharu.kotatsu.parsers.site.madara.tr
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("VIYAFANSUB", "Viya Fansub", "tr")
+internal class ViyaFansub(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.VIYAFANSUB, "viyafansub.com") {
+
+	override val datePattern = "d MMMM yyyy"
+	override val isNsfwSource = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/vi/MangaZodiac.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/vi/MangaZodiac.kt
@@ -1,0 +1,12 @@
+package org.koitharu.kotatsu.parsers.site.madara.vi
+
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+
+
+@MangaSourceParser("MANGAZODIAC", "Manga Zodiac", "vi")
+internal class MangaZodiac(context: MangaLoaderContext) :
+	MadaraParser(context, MangaSource.MANGAZODIAC, "mangazodiac.com")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Areascans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Areascans.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("AREASCANS", "Areascans", "ar")
 internal class Areascans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.AREASCANS, pageSize = 20, searchPageSize = 10) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.areascans.net")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-
-}
+	MangaReaderParser(context, MangaSource.AREASCANS, "www.areascans.net", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Areascans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Areascans.kt
@@ -1,0 +1,20 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.ar
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("AREASCANS", "Areascans", "ar")
+internal class Areascans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.AREASCANS, pageSize = 20, searchPageSize = 10) {
+
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("www.areascans.net")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/BeastScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/BeastScans.kt
@@ -1,0 +1,20 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.ar
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("BEASTSCANS", "Beast Scans", "ar")
+internal class BeastScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.BEASTSCANS, pageSize = 20, searchPageSize = 10) {
+
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("beast-scans.com")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/BeastScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/BeastScans.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("BEASTSCANS", "Beast Scans", "ar")
 internal class BeastScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.BEASTSCANS, pageSize = 20, searchPageSize = 10) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("beast-scans.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-
-}
+	MangaReaderParser(context, MangaSource.BEASTSCANS, "beast-scans.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Galaxymanga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Galaxymanga.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("GALAXYMANGA", "Galaxymanga", "ar")
 internal class Galaxymanga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.GALAXYMANGA, pageSize = 40, searchPageSize = 30) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("galaxymanga.org")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-
-}
+	MangaReaderParser(context, MangaSource.GALAXYMANGA, "galaxymanga.org", pageSize = 40, searchPageSize = 30)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/MangaProtm.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/MangaProtm.kt
@@ -2,20 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGAPROTM", "MangaProtm", "ar")
 internal class MangaProtm(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAPROTM, pageSize = 20, searchPageSize = 20) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangaprotm.com")
+	MangaReaderParser(context, MangaSource.MANGAPROTM, "mangaprotm.com", pageSize = 20, searchPageSize = 20) {
 
 	override val listUrl = "/series"
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Mangaatrend.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Mangaatrend.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGAATREND", "Mangaatrend", "ar")
 internal class Mangaatrend(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAATREND, pageSize = 40, searchPageSize = 20) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangaatrend.net")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-
-}
+	MangaReaderParser(context, MangaSource.MANGAATREND, "mangaatrend.net", pageSize = 40, searchPageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Ozulscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/Ozulscans.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("OZULSCANS", "Ozulscans", "ar")
 internal class Ozulscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.OZULSCANS, pageSize = 30, searchPageSize = 30) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("ozulscans.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("ar", "AR"))
-}
+	MangaReaderParser(context, MangaSource.OZULSCANS, "ozulscans.com", pageSize = 30, searchPageSize = 30)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/SwaTeam.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ar/SwaTeam.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ar
 import org.jsoup.nodes.Document
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaSource
@@ -20,20 +19,16 @@ import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
 import org.koitharu.kotatsu.parsers.util.toTitleCase
 import org.koitharu.kotatsu.parsers.util.tryParse
 import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SWATEAM", "Swa Team", "ar")
 internal class SwaTeam(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SWATEAM, pageSize = 42, searchPageSize = 39) {
+	MangaReaderParser(context, MangaSource.SWATEAM, "swatop.club", pageSize = 42, searchPageSize = 39) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("swatop.club")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("dd-MM-yyyy", Locale("ar", "AR"))
-
+	override val datePattern = "dd-MM-yyyy"
 
 	override suspend fun getDetails(manga: Manga): Manga {
 		val docs = webClient.httpGet(manga.url.toAbsoluteUrl(domain)).parseHtml()
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
 		val chapters = docs.select("div.bixbox li").mapChapters(reversed = true) { index, element ->
 			val url = element.selectFirst("a")?.attrAsRelativeUrl("href") ?: return@mapChapters null
 			MangaChapter(
@@ -42,7 +37,7 @@ internal class SwaTeam(context: MangaLoaderContext) :
 				url = url,
 				number = index + 1,
 				scanlator = null,
-				uploadDate = chapterDateFormat.tryParse(element.selectFirst(".chapterdate")?.text()),
+				uploadDate = dateFormat.tryParse(element.selectFirst(".chapterdate")?.text()),
 				branch = null,
 				source = source,
 			)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AnigliScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AnigliScans.kt
@@ -2,17 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("ANIGLISCANS", "Anigli Scans", "en")
 internal class AnigliScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ANIGLISCANS, pageSize = 47, searchPageSize = 47) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("anigliscans.com")
+	MangaReaderParser(context, MangaSource.ANIGLISCANS, "anigliscans.com", pageSize = 47, searchPageSize = 47) {
 
-	override val listUrl: String
-		get() = "/series"
-
+	override val listUrl = "/series"
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ArenaScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ArenaScans.kt
@@ -2,14 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("ARENASCANS", "Arena Scans", "en")
 internal class ArenaScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ARENASCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("arenascans.net")
+	MangaReaderParser(context, MangaSource.ARENASCANS, "arenascans.net", pageSize = 20, searchPageSize = 20) {
 
+
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AsuraScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AsuraScansParser.kt
@@ -2,15 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("ASURASCANS", "Asura Scans", "en")
 internal class AsuraScansParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ASURASCANS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("asura.gg")
+	MangaReaderParser(context, MangaSource.ASURASCANS, "asura.gg", pageSize = 20, searchPageSize = 10) {
 
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AzureManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/AzureManga.kt
@@ -2,15 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 
 @MangaSourceParser("AZUREMANGA", "Azure Manga", "en")
 internal class AzureManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.AZUREMANGA, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("azuremanga.com")
+	MangaReaderParser(context, MangaSource.AZUREMANGA, "azuremanga.com", pageSize = 20, searchPageSize = 10) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/BabelToon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/BabelToon.kt
@@ -1,0 +1,65 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.en
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
+import org.koitharu.kotatsu.parsers.util.domain
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.mapChapters
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.tryParse
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("BABELTOON", "BabelToon", "en")
+internal class BabelToon(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.BABELTOON, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("babeltoon.com")
+
+	override val listUrl = "/series"
+	override val selectMangaliste = ".postbody .listupd .maindet .inmain"
+	override val chapterDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+
+
+	override suspend fun getDetails(manga: Manga): Manga {
+		val docs = webClient.httpGet(manga.url.toAbsoluteUrl(domain)).parseHtml()
+		val chapters = docs.select(".eplister > ul > li").mapChapters(reversed = true) { index, element ->
+			val url = element.selectFirst("a")?.attrAsRelativeUrl("href") ?: return@mapChapters null
+			MangaChapter(
+				id = generateUid(url),
+				name = element.selectFirst(".epl-num")?.text() ?: "Chapter ${index + 1}",
+				url = url,
+				number = index + 1,
+				scanlator = null,
+				uploadDate = chapterDateFormat.tryParse(element.selectFirst(".epl-date")?.text()),
+				branch = null,
+				source = source,
+			)
+		}
+		return parseInfo(docs, manga, chapters)
+	}
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val chapterUrl = chapter.url.toAbsoluteUrl(domain)
+		val docs = webClient.httpGet(chapterUrl).parseHtml()
+
+		return docs.select("div.epcontent img").map { img ->
+			val url = img.imageUrl()
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/BabelToon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/BabelToon.kt
@@ -2,7 +2,6 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaPage
@@ -16,21 +15,17 @@ import org.koitharu.kotatsu.parsers.util.parseHtml
 import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
 import org.koitharu.kotatsu.parsers.util.tryParse
 import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("BABELTOON", "BabelToon", "en")
 internal class BabelToon(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.BABELTOON, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("babeltoon.com")
+	MangaReaderParser(context, MangaSource.BABELTOON, "babeltoon.com", pageSize = 20, searchPageSize = 10) {
 
 	override val listUrl = "/series"
 	override val selectMangaliste = ".postbody .listupd .maindet .inmain"
-	override val chapterDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
-
 
 	override suspend fun getDetails(manga: Manga): Manga {
 		val docs = webClient.httpGet(manga.url.toAbsoluteUrl(domain)).parseHtml()
+		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
 		val chapters = docs.select(".eplister > ul > li").mapChapters(reversed = true) { index, element ->
 			val url = element.selectFirst("a")?.attrAsRelativeUrl("href") ?: return@mapChapters null
 			MangaChapter(
@@ -39,7 +34,7 @@ internal class BabelToon(context: MangaLoaderContext) :
 				url = url,
 				number = index + 1,
 				scanlator = null,
-				uploadDate = chapterDateFormat.tryParse(element.selectFirst(".epl-date")?.text()),
+				uploadDate = dateFormat.tryParse(element.selectFirst(".epl-date")?.text()),
 				branch = null,
 				source = source,
 			)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/CosmicScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/CosmicScansParser.kt
@@ -2,14 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("COSMICSCANS", "CosmicScans", "en")
 internal class CosmicScansParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.COSMICSCANS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("cosmicscans.com")
+	MangaReaderParser(context, MangaSource.COSMICSCANS, "cosmicscans.com", pageSize = 20, searchPageSize = 10) {
+
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Elarcpage.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Elarcpage.kt
@@ -2,21 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("ELARCPAGE", "Elarcpage", "en")
 internal class Elarcpage(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ELARCPAGE, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("elarcpage.com")
+	MangaReaderParser(context, MangaSource.ELARCPAGE, "elarcpage.com", pageSize = 20, searchPageSize = 10) {
 
-	override val listUrl: String
-		get() = "/series"
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.ENGLISH)
+	override val listUrl = "/series"
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FlameScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FlameScans.kt
@@ -2,16 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("FLAMESCANS", "Flame Scans", "en")
 internal class FlameScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.FLAMESCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("flamescans.org")
+	MangaReaderParser(context, MangaSource.FLAMESCANS, "flamescans.org", pageSize = 20, searchPageSize = 20) {
 
-	override val listUrl: String
-		get() = "/series"
+	override val listUrl = "/series"
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FreakScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FreakScans.kt
@@ -2,14 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("FREAKSCANS", "FreakScans", "en")
 internal class FreakScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.FREAKSCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("freakscans.com")
+	MangaReaderParser(context, MangaSource.FREAKSCANS, "freakscans.com", pageSize = 20, searchPageSize = 20) {
+
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FreakScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/FreakScans.kt
@@ -1,0 +1,15 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.en
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+
+@MangaSourceParser("FREAKSCANS", "FreakScans", "en")
+internal class FreakScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.FREAKSCANS, pageSize = 20, searchPageSize = 20) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("freakscans.com")
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/KumaScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/KumaScans.kt
@@ -2,15 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 
 @MangaSourceParser("KUMASCANS", "Kuma Scans", "en")
 internal class KumaScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KUMASCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("kumascans.com")
+	MangaReaderParser(context, MangaSource.KUMASCANS, "kumascans.com", pageSize = 20, searchPageSize = 20) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/LunarScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/LunarScan.kt
@@ -2,22 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("LUNAR_SCAN", "Lunar Scan", "en")
 internal class LunarScan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LUNAR_SCAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("lunarscan.org")
+	MangaReaderParser(context, MangaSource.LUNAR_SCAN, "lunarscan.org", pageSize = 20, searchPageSize = 20) {
 
 	override val listUrl = "/series"
-
 	override val isNsfwSource: Boolean = true
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ManhwaLover.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ManhwaLover.kt
@@ -2,16 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("MANHWALOVER", "ManhwaLover", "en")
 internal class ManhwaLover(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWALOVER, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwalover.com")
+	MangaReaderParser(context, MangaSource.MANHWALOVER, "manhwalover.com", pageSize = 20, searchPageSize = 20) {
 
 	override val isNsfwSource: Boolean = true
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Manhwax.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Manhwax.kt
@@ -2,15 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("MANHWAX", "Manhwax", "en")
 internal class Manhwax(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWAX, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwax.org")
+	MangaReaderParser(context, MangaSource.MANHWAX, "manhwax.org", pageSize = 20, searchPageSize = 20) {
 
 	override val isNsfwSource: Boolean = true
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Nightscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Nightscans.kt
@@ -2,14 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("NIGHTSCANS", "Nightscans", "en")
 internal class Nightscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.NIGHTSCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("nightscans.org")
+	MangaReaderParser(context, MangaSource.NIGHTSCANS, "nightscans.org", pageSize = 20, searchPageSize = 20) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Phantomscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Phantomscans.kt
@@ -2,14 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("PHANTOMSCANS", "Phantomscans", "en")
 internal class Phantomscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.PHANTOMSCANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("phantomscans.com")
+	MangaReaderParser(context, MangaSource.PHANTOMSCANS, "phantomscans.com", pageSize = 20, searchPageSize = 20) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/QueenScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/QueenScans.kt
@@ -1,0 +1,17 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.en
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+
+@MangaSourceParser("QUEENSCANS", "QueenScans", "en")
+internal class QueenScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.QUEENSCANS, pageSize = 30, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("queenscans.com")
+
+	override val listUrl = "/comics"
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/QueenScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/QueenScans.kt
@@ -2,16 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("QUEENSCANS", "QueenScans", "en")
 internal class QueenScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.QUEENSCANS, pageSize = 30, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("queenscans.com")
+	MangaReaderParser(context, MangaSource.QUEENSCANS, "queenscans.com", pageSize = 30, searchPageSize = 10) {
 
 	override val listUrl = "/comics"
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Ravenscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Ravenscans.kt
@@ -2,14 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("RAVENSCANS", "Ravenscans", "en")
 internal class Ravenscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.RAVENSCANS, pageSize = 10, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("ravenscans.com")
+	MangaReaderParser(context, MangaSource.RAVENSCANS, "ravenscans.com", pageSize = 10, searchPageSize = 10) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Readkomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Readkomik.kt
@@ -2,16 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 
 @MangaSourceParser("READKOMIK", "Readkomik", "en")
 internal class Readkomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.READKOMIK, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("readkomik.com")
+	MangaReaderParser(context, MangaSource.READKOMIK, "readkomik.com", pageSize = 20, searchPageSize = 20) {
 
+	override val datePattern = "MMM d, yyyy"
 }
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/RealmScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/RealmScans.kt
@@ -2,19 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("REALMSCANS", "RealmScans", "en")
 internal class RealmScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.REALMSCANS, pageSize = 30, searchPageSize = 50) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("realmscans.xyz")
+	MangaReaderParser(context, MangaSource.REALMSCANS, "realmscans.xyz", pageSize = 30, searchPageSize = 50) {
 
 	override val listUrl = "/series"
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
+	override val datePattern = "dd MMM yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/SkyManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/SkyManga.kt
@@ -2,19 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("SKY_MANGA", "Sky Manga", "en")
 internal class SkyManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SKY_MANGA, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("skymanga.work")
+	MangaReaderParser(context, MangaSource.SKY_MANGA, "skymanga.work", pageSize = 20, searchPageSize = 20) {
 
 	override val listUrl = "/manga-list"
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("DD-MM-yyy", Locale.ENGLISH)
+	override val datePattern = "DD-MM-yyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Suryascans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/Suryascans.kt
@@ -2,14 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("SURYASCANS", "Suryascans", "en")
 internal class Suryascans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SURYASCANS, pageSize = 5, searchPageSize = 5) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("suryascans.com")
+	MangaReaderParser(context, MangaSource.SURYASCANS, "suryascans.com", pageSize = 5, searchPageSize = 5) {
 
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/VoidScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/VoidScans.kt
@@ -2,13 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.en
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("VOIDSCANS", "Void Scans", "en")
 internal class VoidScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.VOIDSCANS, pageSize = 150, searchPageSize = 150) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("void-scans.com")
+	MangaReaderParser(context, MangaSource.VOIDSCANS, "void-scans.com", pageSize = 150, searchPageSize = 150) {
+
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/CartelDeManhwas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/CartelDeManhwas.kt
@@ -2,20 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("CARTELDEMANHWAS", "Cartel De Manhwas", "es")
 internal class CartelDeManhwas(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.CARTELDEMANHWAS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("carteldemanhwas.com")
+	MangaReaderParser(context, MangaSource.CARTELDEMANHWAS, "carteldemanhwas.com", pageSize = 20, searchPageSize = 20) {
 
-	override val listUrl: String
-		get() = "/series"
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("es", "ES"))
+	override val listUrl = "/series"
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/GREMORYMANGAS.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/GREMORYMANGAS.kt
@@ -2,18 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("GREMORYMANGAS", "Gremory Mangas", "es")
 internal class GREMORYMANGAS(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.GREMORYMANGAS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("gremorymangas.com")
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es", "ES"))
-}
+	MangaReaderParser(context, MangaSource.GREMORYMANGAS, "gremorymangas.com", pageSize = 20, searchPageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/LegionScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/LegionScans.kt
@@ -2,16 +2,16 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("LEGIONSCANS", "Legion Scans", "es")
 internal class LegionScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LEGIONSCANS, pageSize = 20, searchPageSize = 20) {
+	MangaReaderParser(context, MangaSource.LEGIONSCANS, "legionscans.com", pageSize = 20, searchPageSize = 20) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("legionscans.com")
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 
 }
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/MiauScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/MiauScan.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MIAUSCAN", "Miau Scan", "es")
 internal class MiauScan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MIAUSCAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("miauscan.com")
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es", "ES"))
-
-}
+	MangaReaderParser(context, MangaSource.MIAUSCAN, "miauscan.com", pageSize = 20, searchPageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Raikiscan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Raikiscan.kt
@@ -2,17 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("RAIKISCAN", "Raikiscan", "es")
 internal class Raikiscan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.RAIKISCAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("raikiscan.com")
+	MangaReaderParser(context, MangaSource.RAIKISCAN, "raikiscan.com", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("es", "ES"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Senpaiediciones.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Senpaiediciones.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SENPAIEDICIONES", "Senpaiediciones", "es")
 internal class Senpaiediciones(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SENPAIEDICIONES, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("senpaiediciones.com")
+	MangaReaderParser(context, MangaSource.SENPAIEDICIONES, "senpaiediciones.com", pageSize = 20, searchPageSize = 20) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("es", "ES"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Shadowmangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/Shadowmangas.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SHADOWMANGAS", "Shadowmangas", "es")
 internal class Shadowmangas(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SHADOWMANGAS, pageSize = 10, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("shadowmangas.com")
+	MangaReaderParser(context, MangaSource.SHADOWMANGAS, "shadowmangas.com", pageSize = 10, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("es", "ES"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/SkyMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/SkyMangas.kt
@@ -2,19 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.es
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SKYMANGAS", "Sky Mangas", "es")
 internal class SkyMangas(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SKYMANGAS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("skymangas.com")
+	MangaReaderParser(context, MangaSource.SKYMANGAS, "skymangas.com", pageSize = 20, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es", "ES"))
 	override val encodedSrc = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/SkyMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/es/SkyMangas.kt
@@ -1,0 +1,20 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.es
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("SKYMANGAS", "Sky Mangas", "es")
+internal class SkyMangas(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.SKYMANGAS, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("skymangas.com")
+
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("es", "ES"))
+	override val encodedSrc = true
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/BananaScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/BananaScan.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("BANANASCAN", "Banana Scan", "fr")
 internal class BananaScan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.BANANASCAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("banana-scan.com")
+	MangaReaderParser(context, MangaSource.BANANASCAN, "banana-scan.com", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.FRENCH)
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/EpsilonscanParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/EpsilonscanParser.kt
@@ -2,19 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("EPSILONSCAN", "Epsilonscan", "fr")
 internal class EpsilonscanParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.EPSILONSCAN, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("epsilonscan.fr")
+	MangaReaderParser(context, MangaSource.EPSILONSCAN, "epsilonscan.fr", pageSize = 20, searchPageSize = 10) {
 
 	override val isNsfwSource: Boolean = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.FRENCH)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/LegacyScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/LegacyScansParser.kt
@@ -2,18 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("LEGACY_SCANS", "Legacy Scans", "fr")
 internal class LegacyScansParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LEGACY_SCANS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("legacy-scans.com")
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.FRENCH)
-}
+	MangaReaderParser(context, MangaSource.LEGACY_SCANS, "legacy-scans.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/LelManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/LelManga.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 import org.jsoup.nodes.Element
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaPage
 import org.koitharu.kotatsu.parsers.model.MangaSource
@@ -16,16 +15,10 @@ import org.koitharu.kotatsu.parsers.util.requireElementById
 import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
 import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
 import org.koitharu.kotatsu.parsers.util.toRelativeUrl
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("LELMANGA", "LelManga", "fr")
 internal class LelManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LELMANGA, pageSize = 21, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.lelmanga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	MangaReaderParser(context, MangaSource.LELMANGA, "www.lelmanga.com", pageSize = 21, searchPageSize = 20) {
 
 	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
 		val fullUrl = chapter.url.toAbsoluteUrl(domain)
@@ -42,7 +35,7 @@ internal class LelManga(context: MangaLoaderContext) :
 		}
 	}
 
-	protected fun Element.src(): String? {
+	private fun Element.src(): String? {
 		var result = absUrl("data-src")
 		if (result.isEmpty()) result = absUrl("data-cfsrc")
 		if (result.isEmpty()) result = absUrl("src")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/PhenixscansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/PhenixscansParser.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("PHENIXSCANS", "Phenixscans", "fr")
 internal class PhenixscansParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.PHENIXSCANS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("phenixscans.fr")
+	MangaReaderParser(context, MangaSource.PHENIXSCANS, "phenixscans.fr", pageSize = 20, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.FRENCH)
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/SushiScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/SushiScan.kt
@@ -2,18 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SUSHISCAN", "SushiScan", "fr")
 internal class SushiScan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SUSHISCAN, pageSize = 20, searchPageSize = 10) {
+	MangaReaderParser(context, MangaSource.SUSHISCAN, "sushiscan.net", pageSize = 20, searchPageSize = 10) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("sushiscan.net")
 	override val listUrl = "/catalogue"
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.FRENCH)
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/SushiScanFR.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/SushiScanFR.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SUSHISCANFR", "Sushi Scan FR", "fr")
 internal class SushiScanFR(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SUSHISCANFR, pageSize = 36, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("sushiscan.fr")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.FRENCH)
-}
+	MangaReaderParser(context, MangaSource.SUSHISCANFR, "sushiscan.fr", pageSize = 36, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/VfScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/fr/VfScan.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.fr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("VFSCAN", "Vf Scan", "fr")
 internal class VfScan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.VFSCAN, pageSize = 18, searchPageSize = 18) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.vfscan.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.FRENCH)
-}
+	MangaReaderParser(context, MangaSource.VFSCAN, "www.vfscan.com", pageSize = 18, searchPageSize = 18)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/AinzScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/AinzScans.kt
@@ -2,16 +2,17 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("AINZSCANS", "Ainz Scans", "id")
 internal class AinzScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.AINZSCANS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("ainzscans.site")
+	MangaReaderParser(context, MangaSource.AINZSCANS, "ainzscans.site", pageSize = 20, searchPageSize = 10) {
+
 
 	override val listUrl = "/series"
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Boosei.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Boosei.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("BOOSEI", "Boosei", "id")
 internal class Boosei(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.BOOSEI, pageSize = 30, searchPageSize = 30) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("boosei.net")
+	MangaReaderParser(context, MangaSource.BOOSEI, "boosei.net", pageSize = 30, searchPageSize = 30) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Dojing.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Dojing.kt
@@ -2,21 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("DOJING", "Dojing", "id")
 internal class Dojing(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.DOJING, pageSize = 12, searchPageSize = 12) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("dojing.net")
-
+	MangaReaderParser(context, MangaSource.DOJING, "dojing.net", pageSize = 12, searchPageSize = 12) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/DoujinDesuRip.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/DoujinDesuRip.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("DOUJINDESURIP", "Doujin Desu Rip", "id")
 internal class DoujinDesuRip(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.DOUJINDESURIP, pageSize = 10, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("doujindesu.rip")
+	MangaReaderParser(context, MangaSource.DOUJINDESURIP, "doujindesu.rip", pageSize = 10, searchPageSize = 10) {
 
 	override val isNsfwSource = true
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/DoujinDesuRip.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/DoujinDesuRip.kt
@@ -1,0 +1,20 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("DOUJINDESURIP", "Doujin Desu Rip", "id")
+internal class DoujinDesuRip(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.DOUJINDESURIP, pageSize = 10, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("doujindesu.rip")
+
+	override val isNsfwSource = true
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Duniakomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Duniakomik.kt
@@ -2,21 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("DUNIAKOMIK", "Duniakomik", "id")
 internal class Duniakomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.DUNIAKOMIK, pageSize = 12, searchPageSize = 12) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("duniakomik.id")
-
+	MangaReaderParser(context, MangaSource.DUNIAKOMIK, "duniakomik.id", pageSize = 12, searchPageSize = 12) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Kanzenin.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Kanzenin.kt
@@ -2,20 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("KANZENIN", "Kanzenin", "id")
 internal class Kanzenin(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KANZENIN, pageSize = 25, searchPageSize = 25) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("kanzenin.xyz")
+	MangaReaderParser(context, MangaSource.KANZENIN, "kanzenin.xyz", pageSize = 25, searchPageSize = 25) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("in", "ID"))
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Katakomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Katakomik.kt
@@ -2,14 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("KATAKOMIK", "Katakomik", "id")
 internal class Katakomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KATAKOMIK, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("katakomik.online")
+	MangaReaderParser(context, MangaSource.KATAKOMIK, "katakomik.online", pageSize = 20, searchPageSize = 20) {
+
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KiryuuParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KiryuuParser.kt
@@ -2,18 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KIRYUU", "Kiryuu", "id")
 internal class KiryuuParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KIRYUU, pageSize = 30, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("kiryuu.id")
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("in", "ID"))
-}
+	MangaReaderParser(context, MangaSource.KIRYUU, "kiryuu.id", pageSize = 30, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikAvParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikAvParser.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKAV", "Komik Av", "id")
 internal class KomikAvParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKAV, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikav.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("in", "ID"))
-}
+	MangaReaderParser(context, MangaSource.KOMIKAV, "komikav.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikDewasaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikDewasaParser.kt
@@ -2,16 +2,16 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("KOMIKDEWASA", "KomikDewasa", "id")
 internal class KomikDewasaParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKDEWASA, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikdewasa.cfd")
+	MangaReaderParser(context, MangaSource.KOMIKDEWASA, "komikdewasa.cfd", pageSize = 20, searchPageSize = 20) {
 
 	override val listUrl: String = "/komik"
 	override val isNsfwSource: Boolean = true
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikIndoParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikIndoParser.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKINDO", "KomikIndo", "id")
 internal class KomikIndoParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKINDO, pageSize = 20, searchPageSize = 10) {
+	MangaReaderParser(context, MangaSource.KOMIKINDO, "komikindo.co", pageSize = 20, searchPageSize = 10) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikindo.co")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLabParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLabParser.kt
@@ -2,15 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("KOMIKLAB", "KomikLab", "id")
 internal class KomikLabParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKLAB, pageSize = 20, searchPageSize = 10) {
+	MangaReaderParser(context, MangaSource.KOMIKLAB, "komiklab.com", pageSize = 20, searchPageSize = 10) {
 
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komiklab.com")
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLokalParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLokalParser.kt
@@ -2,14 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("KOMIKLOKAL", "Komik Lokal", "id")
 internal class KomikLokalParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKLOKAL, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikmirror.art")
+	MangaReaderParser(context, MangaSource.KOMIKLOKAL, "komikmirror.art", pageSize = 20, searchPageSize = 10) {
+
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikMama.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikMama.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("KOMIKMAMA", "Komik Mama", "id")
 internal class KomikMama(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKMAMA, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikmama.co")
+	MangaReaderParser(context, MangaSource.KOMIKMAMA, "komikmama.co", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikMangaParser.kt
@@ -2,17 +2,17 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("KOMIKMANGA", "KomikManga", "id")
 internal class KomikMangaParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKMANGA, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikhentai.co")
+	MangaReaderParser(context, MangaSource.KOMIKMANGA, "komikhentai.co", pageSize = 20, searchPageSize = 10) {
 
-	override val listUrl: String
-		get() = "/project"
+	override val listUrl = "/project"
+
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikManhwa.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikManhwa.kt
@@ -2,23 +2,16 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKMANHWA", "Komik Manhwa", "id")
 internal class KomikManhwa(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKMANHWA, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikmanhwa.me")
+	MangaReaderParser(context, MangaSource.KOMIKMANHWA, "komikmanhwa.me", pageSize = 20, searchPageSize = 20) {
 
-	override val listUrl: String
-		get() = "/series"
 
+	override val listUrl = "/series"
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikTapParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikTapParser.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKTAP", "KomikTap", "id")
 internal class KomikTapParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKTAP, pageSize = 25, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("92.87.6.124", "komiktap.in")
+	MangaReaderParser(context, MangaSource.KOMIKTAP, "komiktap.in", pageSize = 25, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komikcast.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komikcast.kt
@@ -2,29 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.json.JSONObject
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
-import org.koitharu.kotatsu.parsers.model.Manga
-import org.koitharu.kotatsu.parsers.model.MangaChapter
-import org.koitharu.kotatsu.parsers.model.MangaPage
-import org.koitharu.kotatsu.parsers.model.MangaSource
-import org.koitharu.kotatsu.parsers.model.MangaState
-import org.koitharu.kotatsu.parsers.model.RATING_UNKNOWN
-import org.koitharu.kotatsu.parsers.model.WordSet
+import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import org.koitharu.kotatsu.parsers.util.attrAsAbsoluteUrl
-import org.koitharu.kotatsu.parsers.util.attrAsAbsoluteUrlOrNull
-import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
-import org.koitharu.kotatsu.parsers.util.domain
-import org.koitharu.kotatsu.parsers.util.generateUid
-import org.koitharu.kotatsu.parsers.util.mapChapters
-import org.koitharu.kotatsu.parsers.util.mapNotNullToSet
-import org.koitharu.kotatsu.parsers.util.parseHtml
-import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
-import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
-import org.koitharu.kotatsu.parsers.util.tryParse
+import org.koitharu.kotatsu.parsers.util.*
 import java.text.DateFormat
 import java.util.Calendar
 
@@ -116,13 +99,6 @@ internal class Komikcast(context: MangaLoaderContext) :
 				source = source,
 			)
 		}
-	}
-
-	private fun Element.imageUrl(): String {
-		return attrAsAbsoluteUrlOrNull("src")
-			?: attrAsAbsoluteUrlOrNull("data-src")
-			?: attrAsAbsoluteUrlOrNull("data-cfsrc")
-			?: ""
 	}
 
 	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikgoParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikgoParser.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKGO", "Komikgo", "id")
 internal class KomikgoParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKGO, pageSize = 20, searchPageSize = 10) {
+	MangaReaderParser(context, MangaSource.KOMIKGO, "komikgo.org", pageSize = 20, searchPageSize = 10) {
 
-	override val configKeyDomain: ConfigKey.Domain = ConfigKey.Domain("komikgo.org")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomiklokalCfd.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomiklokalCfd.kt
@@ -1,0 +1,20 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("KOMIKLOKALCFD", "Komiklokal Cfd", "id")
+internal class KomiklokalCfd(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.KOMIKLOKALCFD, pageSize = 30, searchPageSize = 10) {
+
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("komiklokal.cfd")
+
+	override val isNsfwSource = true
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomiklokalCfd.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomiklokalCfd.kt
@@ -2,19 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("KOMIKLOKALCFD", "Komiklokal Cfd", "id")
 internal class KomiklokalCfd(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKLOKALCFD, pageSize = 30, searchPageSize = 10) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komiklokal.cfd")
+	MangaReaderParser(context, MangaSource.KOMIKLOKALCFD, "komiklokal.cfd", pageSize = 30, searchPageSize = 10) {
 
 	override val isNsfwSource = true
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komikstation.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komikstation.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("KOMIKSTATION", "Komikstation", "id")
 internal class Komikstation(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKSTATION, pageSize = 30, searchPageSize = 30) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komikstation.co")
+	MangaReaderParser(context, MangaSource.KOMIKSTATION, "komikstation.co", pageSize = 30, searchPageSize = 30) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komiku.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Komiku.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("KOMIKU", "Komiku", "id")
 internal class Komiku(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.KOMIKU, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("komiku.com")
+	MangaReaderParser(context, MangaSource.KOMIKU, "komiku.com", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Lianscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Lianscans.kt
@@ -2,20 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("LIANSCANS", "Lianscans", "id")
 internal class Lianscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LIANSCANS, pageSize = 10, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.lianscans.my.id")
+	MangaReaderParser(context, MangaSource.LIANSCANS, "www.lianscans.my.id", pageSize = 10, searchPageSize = 10) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangaSusuku.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangaSusuku.kt
@@ -2,18 +2,16 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("MANGASUSUKU", "MangaSusuku", "id")
 internal class MangaSusuku(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGASUSUKU, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangasusuku.xyz")
+	MangaReaderParser(context, MangaSource.MANGASUSUKU, "mangasusuku.xyz", pageSize = 20, searchPageSize = 20) {
 
-	override val listUrl: String
-		get() = "/komik"
-
+	override val listUrl = "/komik"
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 	override val isNsfwSource = true
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangaTaleParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangaTaleParser.kt
@@ -2,18 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("MANGATALE", "MangaTale", "id")
 internal class MangaTaleParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGATALE, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangatale.co")
+	MangaReaderParser(context, MangaSource.MANGATALE, "mangatale.co", pageSize = 20, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mangaindo.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mangaindo.kt
@@ -2,16 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("MANGAINDO", "Mangaindo", "id")
 internal class Mangaindo(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAINDO, pageSize = 26, searchPageSize = 26) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangaindo.me")
+	MangaReaderParser(context, MangaSource.MANGAINDO, "mangaindo.me", pageSize = 26, searchPageSize = 26) {
 
-
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangakKita.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MangakKita.kt
@@ -2,14 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("MANGAKITA", "MangaKita", "id")
 internal class MangakKita(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAKITA, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangakita.net")
+	MangaReaderParser(context, MangaSource.MANGAKITA, "mangakita.net", pageSize = 20, searchPageSize = 20) {
 
+
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mangayaro.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mangayaro.kt
@@ -2,16 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("MANGAYARO", "Mangayaro", "id")
 internal class Mangayaro(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAYARO, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangayaro.net")
+	MangaReaderParser(context, MangaSource.MANGAYARO, "mangayaro.net", pageSize = 20, searchPageSize = 20) {
 
-
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoIcu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoIcu.kt
@@ -2,19 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("MANHWAINDOICU", "Manhwa Indo Icu", "id")
 internal class ManhwaIndoIcu(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWAINDOICU, pageSize = 30, searchPageSize = 10) {
-
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwaindo.icu")
+	MangaReaderParser(context, MangaSource.MANHWAINDOICU, "manhwaindo.icu", pageSize = 30, searchPageSize = 10) {
 
 	override val isNsfwSource = true
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoIcu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoIcu.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site.mangareader.es
+package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
@@ -8,12 +8,13 @@ import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-@MangaSourceParser("DRAGONTRANSLATION", "DragonTranslation", "es")
-internal class DragonTranslationParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.DRAGONTRANSLATION, pageSize = 20, searchPageSize = 10) {
+@MangaSourceParser("MANHWAINDOICU", "Manhwa Indo Icu", "id")
+internal class ManhwaIndoIcu(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.MANHWAINDOICU, pageSize = 30, searchPageSize = 10) {
+
 	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("dragontranslation.net")
+		get() = ConfigKey.Domain("manhwaindo.icu")
 
+	override val isNsfwSource = true
 	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
-
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwaIndoParser.kt
@@ -2,18 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("MANHWAINDO", "Manhwaindo", "id")
 internal class ManhwaIndoParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWAINDO, pageSize = 30, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwaindo.id")
+	MangaReaderParser(context, MangaSource.MANHWAINDO, "manhwaindo.id", pageSize = 30, searchPageSize = 10) {
 
-	override val chapterDateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.ENGLISH)
+	override val datePattern = "MMMM dd, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 	override val listUrl: String get() = "/series"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwadesuParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwadesuParser.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANHWADESU", "ManhwaDesu", "id")
 internal class ManhwadesuParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWADESU, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwadesu.pro", "manhwadesu.org")
+	MangaReaderParser(context, MangaSource.MANHWADESU, "manhwadesu.top", pageSize = 20, searchPageSize = 10) {
 
-	override val listUrl: String get() = "/komik"
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM D, yyyy", Locale("in", "ID"))
+	override val listUrl = "/komik"
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwalistParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/ManhwalistParser.kt
@@ -2,17 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("MANHWALIST", "Manhwalist", "id")
 internal class ManhwalistParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANHWALIST, pageSize = 24, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manhwalist.xyz")
+	MangaReaderParser(context, MangaSource.MANHWALIST, "manhwalist.xyz", pageSize = 24, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MasterKomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/MasterKomik.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 @MangaSourceParser("MASTERKOMIK", "MasterKomik", "id")
 internal class MasterKomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MASTERKOMIK, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("masterkomik.com")
+	MangaReaderParser(context, MangaSource.MASTERKOMIK, "masterkomik.com", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Melokomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Melokomik.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MELOKOMIK", "Melokomik", "id")
 internal class Melokomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MELOKOMIK, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("melokomik.xyz")
+	MangaReaderParser(context, MangaSource.MELOKOMIK, "melokomik.xyz", pageSize = 20, searchPageSize = 20) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mirrordesu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Mirrordesu.kt
@@ -2,23 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MIRRORDESU", "Mirrordesu", "id")
 internal class Mirrordesu(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MIRRORDESU, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mirrordesu.ink")
+	MangaReaderParser(context, MangaSource.MIRRORDESU, "mirrordesu.ink", pageSize = 20, searchPageSize = 20) {
 
-	override val listUrl: String
-		get() = "/komik"
-
+	override val listUrl = "/komik"
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Nonbiri.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Nonbiri.kt
@@ -1,0 +1,18 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.id
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("NONBIRI", "Nonbiri", "id")
+internal class Nonbiri(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.NONBIRI, pageSize = 15, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("nonbiri.space")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Nonbiri.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Nonbiri.kt
@@ -2,17 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("NONBIRI", "Nonbiri", "id")
 internal class Nonbiri(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.NONBIRI, pageSize = 15, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("nonbiri.space")
+	MangaReaderParser(context, MangaSource.NONBIRI, "nonbiri.space", pageSize = 15, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Piscans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Piscans.kt
@@ -2,16 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("PISCANS", "Piscans", "id")
 internal class Piscans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.PISCANS, pageSize = 24, searchPageSize = 24) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("piscans.in")
+	MangaReaderParser(context, MangaSource.PISCANS, "piscans.in", pageSize = 24, searchPageSize = 24) {
 
-
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/SekaikomikParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/SekaikomikParser.kt
@@ -2,16 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SEKAIKOMIK", "Sekaikomik", "id")
 internal class SekaikomikParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SEKAIKOMIK, pageSize = 20, searchPageSize = 100) {
-	override val configKeyDomain: ConfigKey.Domain = ConfigKey.Domain("sekaikomik.pro")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM D, yyyy", Locale("in", "ID"))
-}
+	MangaReaderParser(context, MangaSource.SEKAIKOMIK, "sekaikomik.pro", pageSize = 20, searchPageSize = 100)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Sektedoujin.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Sektedoujin.kt
@@ -2,20 +2,14 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SEKTEDOUJIN", "Sektedoujin", "id")
 internal class Sektedoujin(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SEKTEDOUJIN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("sektedoujin.cc")
+	MangaReaderParser(context, MangaSource.SEKTEDOUJIN, "sektedoujin.cc", pageSize = 20, searchPageSize = 20) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Sheakomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Sheakomik.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SHEAKOMIK", "Sheakomik", "id")
 internal class Sheakomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SHEAKOMIK, pageSize = 40, searchPageSize = 40) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("sheakomik.com")
+	MangaReaderParser(context, MangaSource.SHEAKOMIK, "sheakomik.com", pageSize = 40, searchPageSize = 40) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("in", "ID"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/SoulScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/SoulScans.kt
@@ -2,15 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("SOULSCANS", "Soul Scans", "id")
 internal class SoulScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SOULSCANS, pageSize = 30, searchPageSize = 30) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("soulscans.my.id")
+	MangaReaderParser(context, MangaSource.SOULSCANS, "soulscans.my.id", pageSize = 30, searchPageSize = 30) {
 
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Tukangkomik.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/Tukangkomik.kt
@@ -2,15 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 
 @MangaSourceParser("TUKANGKOMIK", "Tukangkomik", "id")
 internal class Tukangkomik(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.TUKANGKOMIK, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("tukangkomik.id")
+	MangaReaderParser(context, MangaSource.TUKANGKOMIK, "tukangkomik.id", pageSize = 20, searchPageSize = 20) {
 
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/WestmangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/WestmangaParser.kt
@@ -2,17 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("WESTMANGA", "Westmanga", "id")
 internal class WestmangaParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.WESTMANGA, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("westmanga.info")
+	MangaReaderParser(context, MangaSource.WESTMANGA, "westmanga.info", pageSize = 20, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH)
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/it/Walpurgiscan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/it/Walpurgiscan.kt
@@ -2,18 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.it
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("WALPURGISCAN", "Walpurgiscan", "it")
 internal class Walpurgiscan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.WALPURGISCAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("walpurgiscan.it")
+	MangaReaderParser(context, MangaSource.WALPURGISCAN, "walpurgiscan.it", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("it", "IT"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/MangaMate.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/MangaMate.kt
@@ -1,0 +1,21 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.ja
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("MANGAMATE", "Manga Mate", "ja")
+internal class MangaMate(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.MANGAMATE, pageSize = 10, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("manga-mate.org")
+
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("M月 d, yyyy", Locale.ENGLISH)
+	override val encodedSrc = true
+
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/MangaMate.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/MangaMate.kt
@@ -2,20 +2,16 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ja
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 import java.util.Locale
 
 @MangaSourceParser("MANGAMATE", "Manga Mate", "ja")
 internal class MangaMate(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAMATE, pageSize = 10, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manga-mate.org")
+	MangaReaderParser(context, MangaSource.MANGAMATE, "manga-mate.org", pageSize = 10, searchPageSize = 10) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("M月 d, yyyy", Locale.ENGLISH)
+	override val datePattern = "M月 d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 	override val encodedSrc = true
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/Rawkuma.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/ja/Rawkuma.kt
@@ -2,14 +2,15 @@ package org.koitharu.kotatsu.parsers.site.mangareader.ja
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.util.Locale
 
 @MangaSourceParser("RAWKUMA", "Rawkuma", "ja")
 internal class Rawkuma(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.RAWKUMA, pageSize = 54, searchPageSize = 54) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("rawkuma.com")
+	MangaReaderParser(context, MangaSource.RAWKUMA, "rawkuma.com", pageSize = 54, searchPageSize = 54) {
 
+
+	override val datePattern = "MMM d, yyyy"
+	override val sourceLocale: Locale = Locale.ENGLISH
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/FranxxMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/FranxxMangas.kt
@@ -2,20 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("FRANXXMANGAS", "Franxx Mangas", "pt")
 internal class FranxxMangas(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.FRANXXMANGAS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("franxxmangas.net")
+	MangaReaderParser(context, MangaSource.FRANXXMANGAS, "franxxmangas.net", pageSize = 20, searchPageSize = 20) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Mangaschan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Mangaschan.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGASCHAN", "Mangaschan", "pt")
 internal class Mangaschan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGASCHAN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangaschan.com")
+	MangaReaderParser(context, MangaSource.MANGASCHAN, "mangaschan.com", pageSize = 20, searchPageSize = 20) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Mundomangakun.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Mundomangakun.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MUNDOMANGAKUN", "Mundomangakun", "pt")
 internal class Mundomangakun(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MUNDOMANGAKUN, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mundomangakun.com.br")
+	MangaReaderParser(context, MangaSource.MUNDOMANGAKUN, "mundomangakun.com.br", pageSize = 20, searchPageSize = 20) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Origamiorpheans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Origamiorpheans.kt
@@ -2,19 +2,19 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("ORIGAMIORPHEANS", "Origami orpheans", "pt")
 internal class Origamiorpheans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ORIGAMIORPHEANS, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("origami-orpheans.com.br")
+	MangaReaderParser(
+		context,
+		MangaSource.ORIGAMIORPHEANS,
+		"origami-orpheans.com.br",
+		pageSize = 20,
+		searchPageSize = 20,
+	) {
 
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Silencescan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Silencescan.kt
@@ -2,20 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SILENCESCAN", "Silencescan", "pt")
 internal class Silencescan(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SILENCESCAN, pageSize = 35, searchPageSize = 35) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("silencescan.com.br")
+	MangaReaderParser(context, MangaSource.SILENCESCAN, "silencescan.com.br", pageSize = 35, searchPageSize = 35) {
 
 	override val isNsfwSource = true
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
-
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Tsundoku.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/pt/Tsundoku.kt
@@ -2,18 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("TSUNDOKU", "Tsundoku", "pt")
 internal class Tsundoku(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.TSUNDOKU, pageSize = 50, searchPageSize = 50) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("tsundoku.com.br")
+	MangaReaderParser(context, MangaSource.TSUNDOKU, "tsundoku.com.br", pageSize = 50, searchPageSize = 50) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("pt", "PT"))
+	override val datePattern = "MMM d, yyyy"
 
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Doujin69.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Doujin69.kt
@@ -2,19 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("DOUJIN69", "Doujin69", "th")
 internal class Doujin69(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.DOUJIN69, pageSize = 40, searchPageSize = 21) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("doujin69.com")
+	MangaReaderParser(context, MangaSource.DOUJIN69, "doujin69.com", pageSize = 40, searchPageSize = 21) {
 
 	override val isNsfwSource = true
 	override val listUrl = "/doujin"
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/InuManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/InuManga.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("INUMANGA", "Inu Manga", "th")
 internal class InuManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.INUMANGA, pageSize = 40, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.inu-manga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.INUMANGA, "www.inu-manga.com", pageSize = 40, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/LamiManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/LamiManga.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("LAMIMANGA", "Lami Manga", "th")
 internal class LamiManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.LAMIMANGA, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.lami-manga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.LAMIMANGA, "www.lami-manga.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MafiaManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MafiaManga.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MAFIAMANGA", "Mafia Manga", "th")
 internal class MafiaManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MAFIAMANGA, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mafia-manga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.MAFIAMANGA, "mafia-manga.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Manga689.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Manga689.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGA689", "Manga689", "th")
 internal class Manga689(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGA689, pageSize = 45, searchPageSize = 21) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manga689.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.MANGA689, "manga689.com", pageSize = 45, searchPageSize = 21)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MangaMoons.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MangaMoons.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGAMOONS", "Manga Moons", "th")
 internal class MangaMoons(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAMOONS, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("manga-moons.net")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.MANGAMOONS, "manga-moons.net", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MangaMoons.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/MangaMoons.kt
@@ -1,0 +1,18 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.th
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("MANGAMOONS", "Manga Moons", "th")
+internal class MangaMoons(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.MANGAMOONS, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("manga-moons.net")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/PopsManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/PopsManga.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("POPSMANGA", "PopsManga", "th")
 internal class PopsManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.POPSMANGA, pageSize = 20, searchPageSize = 14) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("popsmanga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.POPSMANGA, "popsmanga.com", pageSize = 20, searchPageSize = 14)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Sodsaime.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/Sodsaime.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SODSAIME", "สดใสเมะ", "th")
 internal class Sodsaime(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SODSAIME, pageSize = 40, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.xn--l3c0azab5a2gta.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.SODSAIME, "www.xn--l3c0azab5a2gta.com", pageSize = 40, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/ThaiManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/ThaiManga.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("THAIMANGA", "Thai Manga", "th")
 internal class ThaiManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.THAIMANGA, pageSize = 40, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.thaimanga.net")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("th", "TH"))
-}
+	MangaReaderParser(context, MangaSource.THAIMANGA, "www.thaimanga.net", pageSize = 40, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/ToonHunterParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/th/ToonHunterParser.kt
@@ -2,16 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
 
 @MangaSourceParser("TOONHUNTER", "Toon Hunter", "th")
 internal class ToonHunterParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.TOONHUNTER, pageSize = 30, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("toonhunter.com")
+	MangaReaderParser(context, MangaSource.TOONHUNTER, "toonhunter.com", pageSize = 30, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", sourceLocale)
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AfroditScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AfroditScans.kt
@@ -2,17 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("AFRODITSCANS", "Afrodit Scans", "tr")
 internal class AfroditScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.AFRODITSCANS, pageSize = 24, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("afroditscans.com")
+	MangaReaderParser(context, MangaSource.AFRODITSCANS, "afroditscans.com", pageSize = 24, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("tr"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AfroditScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AfroditScans.kt
@@ -1,0 +1,18 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.tr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("AFRODITSCANS", "Afrodit Scans", "tr")
+internal class AfroditScans(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.AFRODITSCANS, pageSize = 24, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("afroditscans.com")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("tr"))
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AsuraTRParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AsuraTRParser.kt
@@ -2,17 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("ASURATR", "Asura Scans (tr)", "tr")
 internal class AsuraTRParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ASURATR, pageSize = 30, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("asurascanstr.com")
+	MangaReaderParser(context, MangaSource.ASURATR, "asurascanstr.com", pageSize = 30, searchPageSize = 10) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("tr"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AthenaFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AthenaFansub.kt
@@ -1,0 +1,19 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.tr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("ATHENAFANSUB", "AthenaFansub", "tr")
+internal class AthenaFansub(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.ATHENAFANSUB, pageSize = 20, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("athenafansub.com")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AthenaFansub.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/AthenaFansub.kt
@@ -2,18 +2,10 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("ATHENAFANSUB", "AthenaFansub", "tr")
 internal class AthenaFansub(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.ATHENAFANSUB, pageSize = 20, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("athenafansub.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
-}
+	MangaReaderParser(context, MangaSource.ATHENAFANSUB, "athenafansub.com", pageSize = 20, searchPageSize = 10)
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Ayatoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Ayatoon.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("AYATOON", "Ayatoon", "tr")
 internal class Ayatoon(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.AYATOON, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("ayatoon.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr"))
-}
+	MangaReaderParser(context, MangaSource.AYATOON, "ayatoon.com", pageSize = 20, searchPageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Golgebahcesi.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Golgebahcesi.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("GOLGEBAHCESI", "Golgebahcesi", "tr")
 internal class Golgebahcesi(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.GOLGEBAHCESI, pageSize = 14, searchPageSize = 9) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("golgebahcesi.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr"))
-}
+	MangaReaderParser(context, MangaSource.GOLGEBAHCESI, "golgebahcesi.com", pageSize = 14, searchPageSize = 9)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/MajorScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/MajorScans.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MAJORSCANS", "MajorScans", "tr")
 internal class MajorScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MAJORSCANS, pageSize = 20, searchPageSize = 25) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("www.majorscans.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr"))
-}
+	MangaReaderParser(context, MangaSource.MAJORSCANS, "www.majorscans.com", pageSize = 20, searchPageSize = 25)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Mangacim.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Mangacim.kt
@@ -2,17 +2,12 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGACIM", "Mangacim", "tr")
 internal class Mangacim(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGACIM, pageSize = 20, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangacim.com")
+	MangaReaderParser(context, MangaSource.MANGACIM, "mangacim.com", pageSize = 20, searchPageSize = 20) {
 
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMM d, yyyy", Locale("tr"))
+	override val datePattern = "MMM d, yyyy"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Mangaokutr.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/Mangaokutr.kt
@@ -2,17 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("MANGAOKUTR", "Mangaokutr", "tr")
 internal class Mangaokutr(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.MANGAOKUTR, pageSize = 25, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("mangaokutr.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr"))
-}
+	MangaReaderParser(context, MangaSource.MANGAOKUTR, "mangaokutr.com", pageSize = 25, searchPageSize = 20)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/NyxManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/NyxManga.kt
@@ -1,0 +1,19 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.tr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("NYXMANGA", "Nyx Manga", "tr")
+internal class NyxManga(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.NYXMANGA, pageSize = 14, searchPageSize = 10) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("nyxmanga.com")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/NyxManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/NyxManga.kt
@@ -2,18 +2,10 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("NYXMANGA", "Nyx Manga", "tr")
 internal class NyxManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.NYXMANGA, pageSize = 14, searchPageSize = 10) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("nyxmanga.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
-}
+	MangaReaderParser(context, MangaSource.NYXMANGA, "nyxmanga.com", pageSize = 14, searchPageSize = 10)
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/SpartanManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/SpartanManga.kt
@@ -2,18 +2,10 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("SPARTANMANGA", "Spartan Manga", "tr")
 internal class SpartanManga(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.SPARTANMANGA, pageSize = 40, searchPageSize = 20) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("spartanmanga.com.tr")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
-}
+	MangaReaderParser(context, MangaSource.SPARTANMANGA, "spartanmanga.com.tr", pageSize = 40, searchPageSize = 20)
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/SpartanManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/SpartanManga.kt
@@ -1,0 +1,19 @@
+package org.koitharu.kotatsu.parsers.site.mangareader.tr
+
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@MangaSourceParser("SPARTANMANGA", "Spartan Manga", "tr")
+internal class SpartanManga(context: MangaLoaderContext) :
+	MangaReaderParser(context, MangaSource.SPARTANMANGA, pageSize = 40, searchPageSize = 20) {
+	override val configKeyDomain: ConfigKey.Domain
+		get() = ConfigKey.Domain("spartanmanga.com.tr")
+
+	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
+}
+

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/TempestfansubParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/TempestfansubParser.kt
@@ -2,18 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("TEMPESTFANSUB", "Tempestfansub", "tr")
 internal class TempestfansubParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.TEMPESTFANSUB, pageSize = 25, searchPageSize = 40) {
-	override val configKeyDomain: ConfigKey.Domain
-		get() = ConfigKey.Domain("tempestfansub.com")
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
-
-}
+	MangaReaderParser(context, MangaSource.TEMPESTFANSUB, "tempestfansub.com", pageSize = 25, searchPageSize = 40)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/TurktoonParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/tr/TurktoonParser.kt
@@ -2,19 +2,9 @@ package org.koitharu.kotatsu.parsers.site.mangareader.tr
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
-import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.MangaSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 @MangaSourceParser("TURKTOON", "Turktoon", "tr")
 internal class TurktoonParser(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaSource.TURKTOON, pageSize = 20, searchPageSize = 10) {
-
-	override val configKeyDomain: ConfigKey.Domain = ConfigKey.Domain("turktoon.com")
-
-
-	override val chapterDateFormat: SimpleDateFormat = SimpleDateFormat("MMMM d, yyyy", Locale("tr", "TR"))
-
-}
+	MangaReaderParser(context, MangaSource.TURKTOON, "turktoon.com", pageSize = 20, searchPageSize = 10)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/pt/UnionMangasParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/pt/UnionMangasParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.pt
 
 import org.jsoup.nodes.Element
 import org.koitharu.kotatsu.parsers.MangaLoaderContext

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.ru
 
 import androidx.collection.ArrayMap
 import okhttp3.Headers

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/NudeMoonParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/NudeMoonParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.ru
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaParser

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/RemangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/RemangaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.ru
 
 import okhttp3.Headers
 import org.json.JSONArray

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HoneyMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HoneyMangaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.uk
 
 import androidx.collection.ArraySet
 import okhttp3.Interceptor

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/MangaInUaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/MangaInUaParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.uk
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/BlogTruyenParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/BlogTruyenParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.vi
 
 import androidx.collection.ArrayMap
 import okhttp3.Headers

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/NetTruyenParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/NetTruyenParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.vi
 
 import androidx.collection.ArrayMap
 import androidx.collection.ArraySet

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/TruyentranhLHParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/vi/TruyentranhLHParser.kt
@@ -1,4 +1,4 @@
-package org.koitharu.kotatsu.parsers.site
+package org.koitharu.kotatsu.parsers.site.vi
 
 import androidx.collection.ArrayMap
 import androidx.collection.ArraySet


### PR DESCRIPTION
Fix japscan with zormy111's script thanks to him for his work
Fix DragonTranslation

Added a function in magareader to decode the ts_read.run script ( some sites encode it in base64 ) 

add source : 

"ar"
falconmanga.com
mangaleks.com
www.areascans.net
kolmanga.com
beast-scans.com

"ru"
mangazavr.ru 18

"vi"
mangazodiac.com

"th"
www.manhuabug.com
www.manhuakey.com
manga-moons.net

"id"
komiklokal.cfd 18
manhwaindo.icu 18
manhwaplus.pro 18
doujindesu.rip 18
indo18h.com 18
nonbiri.space

"ja"
manga-mate.org

"es"
lectorunitoon.com
cocorip.net
koinoboriscan.com
rightdark-scan.com
traduccionesmoonlight.com
skymangas.com

"en"
babeltoon.com
hentai3z.xyz 18
mangagoyaoi.com 18
hentaixdickgirl.com 18
manhuafast.net
grabber.zone
rio2manga.net 18
arcanescans.com
paritehaber.com
mangadass.com 18
mangadna.com 18
jimanga.com
webcomic.me
v2.comiz.net 18
freakscans.com
duckmanga.com
queenscans.com
manhwaz.com
shibamanga.com

"tr"
athenafansub.com
spartanmanga.com.tr
afroditscans.com
niverafansub.com 18
viyafansub.com 18
www.kuroimanga.com 18
nyxmanga.com