### PR TITLE
prismascan chance Domain

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PrismaScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/PrismaScansParser.kt
@@ -7,6 +7,6 @@ import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 @MangaSourceParser("PRISMA_SCANS", "Prisma Scans", "pt")
 internal class PrismaScansParser(context: MangaLoaderContext) :
-	MadaraParser(context, MangaSource.PRISMA_SCANS, "prismascans.net", 10) {
+	MadaraParser(context, MangaSource.PRISMA_SCANS, "prismacomics.com", 10) {
 	override val datePattern = "MMM dd, yyyy"
 }


### PR DESCRIPTION
PrismaScan mudou da URL do site
Antigo: PrismaScan
Com

Novo: https://prismacomics.com/