### PR TITLE
🔧 Correção: Atualização da URL para Yugen Mangas

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YugenMangas.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/YugenMangas.kt
@@ -7,6 +7,6 @@ import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 @MangaSourceParser("YUGENMANGAS", "Yugen Mangas", "pt")
 internal class YugenMangas(context: MangaLoaderContext) :
-	MadaraParser(context, MangaSource.YUGENMANGAS, "yugenmangas.com.br", 10) {
+	MadaraParser(context, MangaSource.YUGENMANGAS, "yugenmangas.net.br", 10) {
 	override val listUrl = "series/"
 }


### PR DESCRIPTION
🛠️ Descrição:

Esta correção resolve o erro relacionado à classe YugenMangas no módulo kotatsu-parsers. O URL do site Yugen Mangas foi atualizado para "https://yugenmangas.net.br/", e essa correção ajusta o código para refletir a URL correta.

🔄 Alterações Realizadas:

A classe YugenMangas foi atualizada no arquivo MangaDexParser.kt.
A URL do site Yugen Mangas foi corrigida para "https://yugenmangas.net.br/".