### PR TITLE
Fix MangaDex nsfw check

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
@@ -110,7 +110,10 @@ internal class MangaDexParser(context: MangaLoaderContext) : MangaParser(context
 				url = id,
 				publicUrl = "https://$domain/title/$id",
 				rating = RATING_UNKNOWN,
-				isNsfw = attrs.getStringOrNull("contentRating") == "erotica",
+				isNsfw = when (attrs.getStringOrNull("contentRating")) {
+					"erotica", "pornographic" -> true
+					else -> false
+				},
 				coverUrl = cover?.plus(".256.jpg").orEmpty(),
 				largeCoverUrl = cover,
 				description = attrs.optJSONObject("description")?.selectByLocale(),


### PR DESCRIPTION
Additionally check for the `pornographic` content rating when labeling a work as sfw or nsfw.