### PR TITLE
Feature Add Exclude Tags And Content Rating Filter

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/ErrorMessages.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/ErrorMessages.kt
@@ -4,6 +4,8 @@ object ErrorMessages {
 
 	const val FILTER_MULTIPLE_STATES_NOT_SUPPORTED = "Multiple states are not supported by this source"
 	const val FILTER_MULTIPLE_GENRES_NOT_SUPPORTED = "Multiple genres are not supported by this source"
+	const val FILTER_MULTIPLE_CONTENT_RATING_NOT_SUPPORTED =
+		"Multiple Content Rating are not supported by this source"
 	const val FILTER_BOTH_LOCALE_GENRES_NOT_SUPPORTED =
 		"Filtering by both genres and locale is not supported by this source"
 	const val FILTER_BOTH_STATES_GENRES_NOT_SUPPORTED =

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
@@ -42,6 +42,11 @@ abstract class MangaParser @InternalParsersApi constructor(
 	 */
 	open val isMultipleTagsSupported: Boolean = true
 
+	/**
+	 * Whether parser supports tagsExclude field in filter
+	 */
+	open val isTagsExclusionSupported: Boolean = false
+
 	@Deprecated(
 		message = "Use availableSortOrders instead",
 		replaceWith = ReplaceWith("availableSortOrders"),

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
@@ -95,6 +95,7 @@ abstract class MangaParser @InternalParsersApi constructor(
 		offset: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> = throw NotImplementedError("Please implement getList(offset, filter) instead")
 
@@ -130,18 +131,29 @@ abstract class MangaParser @InternalParsersApi constructor(
 			"org.koitharu.kotatsu.parsers.model.MangaListFilter",
 		),
 	)
-	open suspend fun getList(offset: Int, tags: Set<MangaTag>?, sortOrder: SortOrder?): List<Manga> {
+	open suspend fun getList(
+		offset: Int,
+		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
+		sortOrder: SortOrder?,
+	): List<Manga> {
 		return getList(
 			offset,
-			MangaListFilter.Advanced(sortOrder ?: defaultSortOrder, tags.orEmpty(), null, emptySet()),
+			MangaListFilter.Advanced(
+				sortOrder ?: defaultSortOrder,
+				tags.orEmpty(),
+				tagsExclude.orEmpty(),
+				null,
+				emptySet(),
+			),
 		)
 	}
 
 	open suspend fun getList(offset: Int, filter: MangaListFilter?): List<Manga> {
 		return when (filter) {
-			is MangaListFilter.Advanced -> getList(offset, null, filter.tags, filter.sortOrder)
-			is MangaListFilter.Search -> getList(offset, filter.query, null, defaultSortOrder)
-			null -> getList(offset, null, null, defaultSortOrder)
+			is MangaListFilter.Advanced -> getList(offset, null, filter.tags, filter.tagsExclude, filter.sortOrder)
+			is MangaListFilter.Search -> getList(offset, filter.query, null, null, defaultSortOrder)
+			null -> getList(offset, null, null, null, defaultSortOrder)
 		}
 	}
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaParser.kt
@@ -33,6 +33,10 @@ abstract class MangaParser @InternalParsersApi constructor(
 	open val availableStates: Set<MangaState>
 		get() = emptySet()
 
+
+	open val availableContentRating: Set<ContentRating>
+		get() = emptySet()
+
 	/**
 	 * Whether parser supports filtering by more than one tag
 	 */
@@ -144,6 +148,7 @@ abstract class MangaParser @InternalParsersApi constructor(
 				tags.orEmpty(),
 				tagsExclude.orEmpty(),
 				null,
+				emptySet(),
 				emptySet(),
 			),
 		)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/PagedMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/PagedMangaParser.kt
@@ -36,6 +36,7 @@ abstract class PagedMangaParser(
 		offset: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> = throw UnsupportedOperationException("You should use getListPage for PagedMangaParser")
 
@@ -43,14 +44,15 @@ abstract class PagedMangaParser(
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> = throw NotImplementedError("Please implement getListPage(page, filter) instead")
 
 	open suspend fun getListPage(page: Int, filter: MangaListFilter?): List<Manga> {
 		return when (filter) {
-			is MangaListFilter.Advanced -> getListPage(page, null, filter.tags, filter.sortOrder)
-			is MangaListFilter.Search -> getListPage(page, filter.query, null, defaultSortOrder)
-			null -> getListPage(page, null, null, defaultSortOrder)
+			is MangaListFilter.Advanced -> getListPage(page, null, filter.tags, filter.tagsExclude, filter.sortOrder)
+			is MangaListFilter.Search -> getListPage(page, filter.query, null, null, defaultSortOrder)
+			null -> getListPage(page, null, null, null, defaultSortOrder)
 		}
 	}
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/model/ContentRating.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/model/ContentRating.kt
@@ -1,0 +1,7 @@
+package org.koitharu.kotatsu.parsers.model
+
+enum class ContentRating {
+	SAFE,
+	SUGGESTIVE,
+	ADULT
+}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/model/MangaListFilter.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/model/MangaListFilter.kt
@@ -20,10 +20,11 @@ sealed interface MangaListFilter {
 	data class Advanced(
 		override val sortOrder: SortOrder,
 		@JvmField val tags: Set<MangaTag>,
+		@JvmField val tagsExclude: Set<MangaTag>,
 		@JvmField val locale: Locale?,
 		@JvmField val states: Set<MangaState>,
 	) : MangaListFilter {
 
-		override fun isEmpty(): Boolean = tags.isEmpty() && locale == null && states.isEmpty()
+		override fun isEmpty(): Boolean = tags.isEmpty() && tagsExclude.isEmpty() && locale == null && states.isEmpty()
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/model/MangaListFilter.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/model/MangaListFilter.kt
@@ -23,8 +23,9 @@ sealed interface MangaListFilter {
 		@JvmField val tagsExclude: Set<MangaTag>,
 		@JvmField val locale: Locale?,
 		@JvmField val states: Set<MangaState>,
+		@JvmField val contentRating: Set<ContentRating>,
 	) : MangaListFilter {
 
-		override fun isEmpty(): Boolean = tags.isEmpty() && tagsExclude.isEmpty() && locale == null && states.isEmpty()
+		override fun isEmpty(): Boolean = tags.isEmpty() && tagsExclude.isEmpty() && locale == null && states.isEmpty() && contentRating.isEmpty()
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
@@ -31,6 +31,7 @@ internal class AnibelParser(context: MangaLoaderContext) : MangaParser(context, 
 		offset: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		if (!query.isNullOrEmpty()) {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
@@ -32,6 +32,8 @@ internal class BentomangaParser(context: MangaLoaderContext) : PagedMangaParser(
 	override val availableStates: Set<MangaState> =
 		EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.PAUSED, MangaState.ABANDONED)
 
+	override val isTagsExclusionSupported = true
+
 	init {
 		paginator.firstPage = 0
 		searchPaginator.firstPage = 0

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
@@ -63,6 +63,10 @@ internal class BentomangaParser(context: MangaLoaderContext) : PagedMangaParser(
 					url.addQueryParameter("withCategories", filter.tags.joinToString(",") { it.key })
 				}
 
+				if (filter.tagsExclude.isNotEmpty()) {
+					url.addQueryParameter("withoutCategories", filter.tagsExclude.joinToString(",") { it.key })
+				}
+
 				filter.states.oneOrThrowIfMany()?.let {
 					url.addQueryParameter(
 						"state",

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
@@ -37,6 +37,7 @@ internal class DesuMeParser(context: MangaLoaderContext) : PagedMangaParser(cont
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		if (query != null && page != searchPaginator.firstPage) {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/NudeMoonParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/NudeMoonParser.kt
@@ -48,6 +48,7 @@ internal class NudeMoonParser(
 		offset: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		val domain = domain

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/RemangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/RemangaParser.kt
@@ -77,6 +77,7 @@ internal class RemangaParser(
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		copyCookies()

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/multichan/ChanParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/multichan/ChanParser.kt
@@ -32,6 +32,7 @@ internal abstract class ChanParser(
 		offset: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		val domain = domain

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/MangaLibParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/MangaLibParser.kt
@@ -44,6 +44,7 @@ internal open class MangaLibParser(
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		if (!query.isNullOrEmpty()) {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HentaiUkrParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HentaiUkrParser.kt
@@ -67,7 +67,13 @@ class HentaiUkrParser(context: MangaLoaderContext) : MangaParser(context, MangaS
 		)
 	}
 
-	override suspend fun getList(offset: Int, query: String?, tags: Set<MangaTag>?, sortOrder: SortOrder): List<Manga> {
+	override suspend fun getList(
+		offset: Int,
+		query: String?,
+		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
+		sortOrder: SortOrder,
+	): List<Manga> {
 		// Get all manga
 		val json = allManga.get().toMutableList()
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HoneyMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/HoneyMangaParser.kt
@@ -80,6 +80,7 @@ class HoneyMangaParser(context: MangaLoaderContext) : PagedMangaParser(context, 
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		val body = JSONObject()

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/MangaInUaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/uk/MangaInUaParser.kt
@@ -34,6 +34,7 @@ class MangaInUaParser(context: MangaLoaderContext) : PagedMangaParser(
 		page: Int,
 		query: String?,
 		tags: Set<MangaTag>?,
+		tagsExclude: Set<MangaTag>?,
 		sortOrder: SortOrder,
 	): List<Manga> {
 		val url = when {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/util/MangaParserEnv.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/util/MangaParserEnv.kt
@@ -68,6 +68,15 @@ fun Set<MangaState>?.oneOrThrowIfMany(): MangaState? {
 	}
 }
 
+@InternalParsersApi
+fun Set<ContentRating>?.oneOrThrowIfMany(): ContentRating? {
+	return when {
+		isNullOrEmpty() -> null
+		size == 1 -> first()
+		else -> throw IllegalArgumentException(ErrorMessages.FILTER_MULTIPLE_CONTENT_RATING_NOT_SUPPORTED)
+	}
+}
+
 val MangaParser.domain: String
 	get() {
 		return config[configKeyDomain]

--- a/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaParserTest.kt
+++ b/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaParserTest.kt
@@ -61,7 +61,7 @@ internal class MangaParserTest {
 			offset = 0,
 			filter = MangaListFilter.Advanced(
 				sortOrder = SortOrder.POPULARITY,
-				tags = emptySet(), locale = null, states = emptySet(), tagsExclude = emptySet(),
+				tags = emptySet(), locale = null, states = emptySet(), tagsExclude = emptySet(), contentRating = emptySet()
 			),
 		).minByOrNull {
 			it.title.length
@@ -130,6 +130,7 @@ internal class MangaParserTest {
 			tagsExclude = setOf(),
 			locale = locales.random(),
 			states = setOf(),
+			contentRating = setOf(),
 		)
 		val list = parser.getList(offset = 0, filter)
 		checkMangaList(list, filter.locale.toString())

--- a/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaParserTest.kt
+++ b/src/test/kotlin/org/koitharu/kotatsu/parsers/MangaParserTest.kt
@@ -28,7 +28,7 @@ internal class MangaParserTest {
 	@MangaSources
 	fun list(source: MangaSource) = runTest(timeout = timeout) {
 		val parser = context.newParserInstance(source)
-		val list = parser.getList(0, sortOrder = SortOrder.POPULARITY, tags = null)
+		val list = parser.getList(0, sortOrder = SortOrder.POPULARITY, tags = null, tagsExclude = null)
 		checkMangaList(list, "list")
 		assert(list.all { it.source == source })
 	}
@@ -61,7 +61,7 @@ internal class MangaParserTest {
 			offset = 0,
 			filter = MangaListFilter.Advanced(
 				sortOrder = SortOrder.POPULARITY,
-				tags = emptySet(), locale = null, states = emptySet(),
+				tags = emptySet(), locale = null, states = emptySet(), tagsExclude = emptySet(),
 			),
 		).minByOrNull {
 			it.title.length
@@ -92,7 +92,7 @@ internal class MangaParserTest {
 		assert(tags.all { it.source == source })
 
 		val tag = tags.last()
-		val list = parser.getList(offset = 0, tags = setOf(tag), sortOrder = null)
+		val list = parser.getList(offset = 0, tags = setOf(tag), tagsExclude = setOf(tag), sortOrder = null)
 		checkMangaList(list, "${tag.title} (${tag.key})")
 		assert(list.all { it.source == source })
 	}
@@ -104,7 +104,7 @@ internal class MangaParserTest {
 		val tags = parser.getAvailableTags().shuffled().take(2).toSet()
 
 		val list = try {
-			parser.getList(offset = 0, tags = tags, sortOrder = null)
+			parser.getList(offset = 0, tags = tags, tagsExclude = tags, sortOrder = null)
 		} catch (e: IllegalArgumentException) {
 			if (e.message == "Multiple genres are not supported by this source") {
 				return@runTest
@@ -127,6 +127,7 @@ internal class MangaParserTest {
 		val filter = MangaListFilter.Advanced(
 			sortOrder = parser.availableSortOrders.first(),
 			tags = setOf(),
+			tagsExclude = setOf(),
 			locale = locales.random(),
 			states = setOf(),
 		)
@@ -140,7 +141,7 @@ internal class MangaParserTest {
 	@MangaSources
 	fun details(source: MangaSource) = runTest(timeout = timeout) {
 		val parser = context.newParserInstance(source)
-		val list = parser.getList(0, sortOrder = SortOrder.POPULARITY, tags = null)
+		val list = parser.getList(0, sortOrder = SortOrder.POPULARITY, tags = null, tagsExclude = null)
 		val manga = list[3]
 		parser.getDetails(manga).apply {
 			assert(!chapters.isNullOrEmpty()) { "Chapters are null or empty" }
@@ -169,7 +170,7 @@ internal class MangaParserTest {
 	@MangaSources
 	fun pages(source: MangaSource) = runTest(timeout = timeout) {
 		val parser = context.newParserInstance(source)
-		val list = parser.getList(0, sortOrder = SortOrder.UPDATED, tags = null)
+		val list = parser.getList(0, sortOrder = SortOrder.UPDATED, tags = null, tagsExclude = null)
 		val manga = list.first()
 		val chapter = parser.getDetails(manga).chapters?.firstOrNull() ?: error("Chapter is null at ${manga.publicUrl}")
 		val pages = parser.getPages(chapter)


### PR DESCRIPTION
I just did it on 1 source, because I'm not sure it's the right method to add it.
Plenty of others are compatible ( mangadex , the mangareader template ect ) I'll add them once I know if it's the right method.

I think we need to add an option like for multiple tags to set to true if the source is compatible with tag exclusion.

I've also added a filter for the type of content ( safe / subjective / adult ) which might be a good idea to couple with the app's option to automatically select "safe" on compatible sources if the don't display nsfw content option is enabled.
