### PR TITLE
Broken parser annotation

### DIFF
--- a/kotatsu-parsers-ksp/src/main/kotlin/org/koitharu/kotatsu/parsers/ksp/ParserProcessor.kt
+++ b/kotatsu-parsers-ksp/src/main/kotlin/org/koitharu/kotatsu/parsers/ksp/ParserProcessor.kt
@@ -85,8 +85,9 @@ class ParserProcessor(
 					val title: String,
 					val locale: String?,
 					val contentType: ContentType,
+					val isBroken: Boolean,
 				) {
-					LOCAL("Local", null, ContentType.OTHER),
+					LOCAL("Local", null, ContentType.OTHER, false),
 				
 			""".trimIndent(),
 		)
@@ -109,7 +110,7 @@ class ParserProcessor(
 		)
 		sourcesWriter?.write(
 			"""
-				DUMMY("Dummy", null, ContentType.OTHER),
+				DUMMY("Dummy", null, ContentType.OTHER, false),
 				;
 			}
 			""".trimIndent(),
@@ -129,6 +130,7 @@ class ParserProcessor(
 			}
 			val annotation = classDeclaration.annotations.single { it.shortName.asString() == "MangaSourceParser" }
 			val deprecation = classDeclaration.annotations.singleOrNull { it.shortName.asString() == "Deprecated" }
+			val isBroken = classDeclaration.annotations.any { it.shortName.asString() == "Broken" }
 			val name = annotation.arguments.single { it.name?.asString() == "name" }.value as String
 			val title = annotation.arguments.single { it.name?.asString() == "title" }.value as String
 			val locale = annotation.arguments.single { it.name?.asString() == "locale" }.value as String
@@ -165,7 +167,7 @@ class ParserProcessor(
 				"@Deprecated(\"$reason\") "
 			} else ""
 			val localeComment = localeTitle?.toTitleCase(localeObj)?.let { " /* $it */" }.orEmpty()
-			sourcesWriter?.write("\t$deprecationString$name(\"$title\", $localeString$localeComment, ContentType.$type),\n")
+			sourcesWriter?.write("\t$deprecationString$name(\"$title\", $localeString$localeComment, ContentType.$type, $isBroken),\n")
 		}
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/Broken.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/Broken.kt
@@ -1,0 +1,8 @@
+package org.koitharu.kotatsu.parsers
+
+/**
+ * Annotate [MangaParser] implementation to mark this parser as broken instead of removing it
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Broken

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaSourceParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/MangaSourceParser.kt
@@ -6,6 +6,7 @@ import org.koitharu.kotatsu.parsers.model.ContentType
  * Annotate each [MangaParser] implementation with this annotation, used by codegen
  */
 @Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
 annotation class MangaSourceParser(
 	/**
 	 * Name of manga source. Used as an Enum value, must be UPPER_CASE and unique.


### PR DESCRIPTION
The main idea of this concept is marking parsers as "broken" instead of removing. This flag will be added to MangaSource and such sources might be hidden from list/catalog whereas manga from these sources will be available to user (via history/favorites).

Not sure it is a 100% good idea so opinions regarding this feature are welcoming