### PR TITLE
Baozimh: Fix for not getting all chapter details

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zh/Baozimh.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zh/Baozimh.kt
@@ -163,8 +163,9 @@ internal class Baozimh(context: MangaLoaderContext) :
 				else -> null
 			},
 			tags = tags,
-			chapters = doc.requireElementById("chapter-items").select("div.comics-chapters a")
-				.mapChapters(reversed = true) { i, a ->
+			chapters = (doc.requireElementById("chapter-items").select("div.comics-chapters a")
+				+ doc.requireElementById("chapters_other_list").select("div.comics-chapters a"))
+				.mapChapters { i, a ->
 					val url = a.attrAsRelativeUrl("href").toAbsoluteUrl(domain)
 					MangaChapter(
 						id = generateUid(url),


### PR DESCRIPTION
The parser was always only getting the first 24 chapters of the manga under the div with `id=chapter-items`.
This pull request is to fix it by adding the rest of the chapters under the div with `id=chapters_other_list`.