### PR TITLE
fix mangaboxparser white space coding in search query

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangabox/MangaboxParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangabox/MangaboxParser.kt
@@ -59,7 +59,7 @@ internal abstract class MangaboxParser(
 
 				is MangaListFilter.Search -> {
 					append("&keyw=")
-					append(filter.query.urlEncoded())
+					append(filter.query.replace(" ", "_").urlEncoded())
 				}
 
 				is MangaListFilter.Advanced -> {


### PR DESCRIPTION
Currently mangabox sources like manganato return empty result when searched. I found this is because they expect white space to be set as `_` in the query string.

https://github.com/KotatsuApp/kotatsu-parsers/issues/551