### PR TITLE
MangaFire: title case selected tag

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaFireParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaFireParser.kt
@@ -160,7 +160,7 @@ internal abstract class MangaFireParser(
 				if (tag == "Hentai" || tag == "Ecchi") {
 					isNsfw = true
 				}
-				availableTags[tag]
+				availableTags[tag.toTitleCase(sourceLocale)]
 			},
 			isNsfw = isNsfw,
 			state = document.selectFirst(".info > p")?.ownText()?.let {


### PR DESCRIPTION
otherwise it may not find tag from the map

needed due to https://github.com/KotatsuApp/kotatsu-parsers/pull/776#discussion_r1614657857