### PR TITLE
Add Asc on some SortOrder

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/model/SortOrder.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/model/SortOrder.kt
@@ -2,9 +2,13 @@ package org.koitharu.kotatsu.parsers.model
 
 enum class SortOrder {
 	UPDATED,
+	UPDATED_ASC,
 	POPULARITY,
+	POPULARITY_ASC,
 	RATING,
+	RATING_ASC,
 	NEWEST,
+	NEWEST_ASC,
 	ALPHABETICAL,
-	ALPHABETICAL_DESC
+	ALPHABETICAL_DESC,
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaDexParser.kt
@@ -85,11 +85,15 @@ internal class MangaDexParser(context: MangaLoaderContext) : MangaParser(context
 					append(
 						when (filter.sortOrder) {
 							SortOrder.UPDATED -> "[latestUploadedChapter]=desc"
+							SortOrder.UPDATED_ASC -> "[latestUploadedChapter]=asc"
 							SortOrder.RATING -> "[rating]=desc"
+							SortOrder.RATING_ASC -> "[rating]=asc"
 							SortOrder.ALPHABETICAL -> "[title]=asc"
 							SortOrder.ALPHABETICAL_DESC -> "[title]=desc"
 							SortOrder.NEWEST -> "[createdAt]=desc"
+							SortOrder.NEWEST_ASC -> "[createdAt]=asc"
 							SortOrder.POPULARITY -> "[followedCount]=desc"
+							SortOrder.POPULARITY_ASC -> "[followedCount]=asc"
 						},
 					)
 					filter.states.forEach {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/Manhwa18Parser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/Manhwa18Parser.kt
@@ -87,6 +87,7 @@ class Manhwa18Parser(context: MangaLoaderContext) :
 							SortOrder.UPDATED -> "update"
 							SortOrder.NEWEST -> "new"
 							SortOrder.RATING -> "like"
+							else -> null
 						},
 					)
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/es/TuMangaOnlineParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/es/TuMangaOnlineParser.kt
@@ -57,11 +57,15 @@ class TuMangaOnlineParser(context: MangaLoaderContext) : PagedMangaParser(
 					append(
 						when (filter.sortOrder) {
 							SortOrder.POPULARITY -> "likes_count&order_dir=desc"
+							SortOrder.POPULARITY_ASC -> "likes_count&order_dir=asc"
 							SortOrder.UPDATED -> "release_date&order_dir=desc"
+							SortOrder.UPDATED_ASC -> "release_date&order_dir=asc"
 							SortOrder.NEWEST -> "creation&order_dir=desc"
+							SortOrder.NEWEST_ASC -> "creation&order_dir=asc"
 							SortOrder.ALPHABETICAL -> "alphabetically&order_dir=asc"
 							SortOrder.ALPHABETICAL_DESC -> "alphabetically&order_dir=desc"
 							SortOrder.RATING -> "score&order_dir=desc"
+							SortOrder.RATING_ASC -> "score&order_dir=asc"
 						},
 					)
 					append("&filter_by=title")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/FmreaderParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/FmreaderParser.kt
@@ -28,7 +28,9 @@ internal abstract class FmreaderParser(
 
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
 		SortOrder.UPDATED,
+		SortOrder.UPDATED_ASC,
 		SortOrder.POPULARITY,
+		SortOrder.POPULARITY_ASC,
 		SortOrder.ALPHABETICAL,
 		SortOrder.ALPHABETICAL_DESC,
 	)
@@ -94,11 +96,13 @@ internal abstract class FmreaderParser(
 
 					append("&sort=")
 					when (filter.sortOrder) {
-						SortOrder.POPULARITY -> append("views")
-						SortOrder.UPDATED -> append("last_update")
+						SortOrder.POPULARITY -> append("views&sort_type=DESC")
+						SortOrder.POPULARITY_ASC -> append("views&sort_type=ASC")
+						SortOrder.UPDATED -> append("last_update&sort_type=DESC")
+						SortOrder.UPDATED_ASC -> append("last_update&sort_type=ASC")
 						SortOrder.ALPHABETICAL -> append("name&sort_type=ASC")
 						SortOrder.ALPHABETICAL_DESC -> append("name&sort_type=DESC")
-						else -> append("last_update")
+						else -> append("last_update&sort_type=DESC")
 					}
 
 					append("&m_status=")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/en/Manhwa18Com.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/en/Manhwa18Com.kt
@@ -52,6 +52,7 @@ internal class Manhwa18Com(context: MangaLoaderContext) :
 							SortOrder.UPDATED -> "update"
 							SortOrder.NEWEST -> "new"
 							SortOrder.RATING -> "like"
+							else -> null
 						},
 					)
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/es/OlimpoScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/es/OlimpoScans.kt
@@ -43,11 +43,13 @@ internal class OlimpoScans(context: MangaLoaderContext) :
 						append(page.toString())
 						append("&sort=")
 						when (filter.sortOrder) {
-							SortOrder.POPULARITY -> append("views")
-							SortOrder.UPDATED -> append("last_update")
+							SortOrder.POPULARITY -> append("views&sort_type=DESC")
+							SortOrder.POPULARITY_ASC -> append("views&sort_type=ASC")
+							SortOrder.UPDATED -> append("last_update&sort_type=DESC")
+							SortOrder.UPDATED_ASC -> append("last_update&sort_type=ASC")
 							SortOrder.ALPHABETICAL -> append("name&sort_type=ASC")
 							SortOrder.ALPHABETICAL_DESC -> append("name&sort_type=DESC")
-							else -> append("last_update")
+							else -> append("last_update&sort_type=DESC")
 						}
 					}
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/BentomangaParser.kt
@@ -77,6 +77,9 @@ internal class BentomangaParser(context: MangaLoaderContext) :
 
 					SortOrder.ALPHABETICAL_DESC -> url.addQueryParameter("order_by", "name")
 						.addQueryParameter("order", "desc")
+
+					else -> url.addQueryParameter("order_by", "update")
+						.addQueryParameter("order", "desc")
 				}
 
 				if (filter.tags.isNotEmpty()) {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/heancms/HeanCms.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/heancms/HeanCms.kt
@@ -32,8 +32,11 @@ internal abstract class HeanCms(
 		SortOrder.ALPHABETICAL,
 		SortOrder.ALPHABETICAL_DESC,
 		SortOrder.UPDATED,
+		SortOrder.UPDATED_ASC,
 		SortOrder.NEWEST,
+		SortOrder.NEWEST_ASC,
 		SortOrder.POPULARITY,
+		SortOrder.POPULARITY_ASC,
 	)
 
 	override val availableStates: Set<MangaState> =
@@ -74,8 +77,11 @@ internal abstract class HeanCms(
 					append("&orderBy=")
 					when (filter.sortOrder) {
 						SortOrder.POPULARITY -> append("total_views&order=desc")
+						SortOrder.POPULARITY_ASC -> append("total_views&order=asc")
 						SortOrder.UPDATED -> append("$paramsUpdated&order=desc")
+						SortOrder.UPDATED_ASC -> append("$paramsUpdated&order=asc")
 						SortOrder.NEWEST -> append("created_at&order=desc")
+						SortOrder.NEWEST_ASC -> append("created_at&order=asc")
 						SortOrder.ALPHABETICAL -> append("title&order=asc")
 						SortOrder.ALPHABETICAL_DESC -> append("title&order=desc")
 						else -> append("latest&order=desc")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/MadaraParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/MadaraParser.kt
@@ -58,9 +58,13 @@ internal abstract class MadaraParser(
 
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
 		SortOrder.UPDATED,
+		SortOrder.UPDATED_ASC,
 		SortOrder.POPULARITY,
+		SortOrder.POPULARITY_ASC,
 		SortOrder.NEWEST,
+		SortOrder.NEWEST_ASC,
 		SortOrder.ALPHABETICAL,
+		SortOrder.ALPHABETICAL_DESC,
 		SortOrder.RATING,
 	)
 
@@ -302,15 +306,48 @@ internal abstract class MadaraParser(
 					}
 
 					when (filter.sortOrder) {
-						SortOrder.POPULARITY -> payload["vars[meta_key]"] = "_wp_manga_views"
-						SortOrder.UPDATED -> payload["vars[meta_key]"] = "_latest_update"
-						SortOrder.NEWEST -> payload["vars[meta_key]"] = ""
+						SortOrder.POPULARITY -> {
+							payload["vars[meta_key]"] = "_wp_manga_views"
+							payload["vars[order]"] = "desc"
+						}
+
+						SortOrder.POPULARITY_ASC -> {
+							payload["vars[meta_key]"] = "_wp_manga_views"
+							payload["vars[order]"] = "asc"
+						}
+
+						SortOrder.UPDATED -> {
+							payload["vars[meta_key]"] = "_latest_update"
+							payload["vars[order]"] = "desc"
+						}
+
+						SortOrder.UPDATED_ASC -> {
+							payload["vars[meta_key]"] = "_latest_update"
+							payload["vars[order]"] = "asc"
+						}
+
+						SortOrder.NEWEST -> {
+							payload["vars[orderby]"] = "date"
+							payload["vars[order]"] = "desc"
+						}
+
+						SortOrder.NEWEST_ASC -> {
+							payload["vars[orderby]"] = "date"
+							payload["vars[order]"] = "asc"
+						}
+
 						SortOrder.ALPHABETICAL -> {
 							payload["vars[orderby]"] = "post_title"
-							payload["vars[order]"] = "ASC"
+							payload["vars[order]"] = "asc"
+						}
+
+						SortOrder.ALPHABETICAL_DESC -> {
+							payload["vars[orderby]"] = "post_title"
+							payload["vars[order]"] = "desc"
 						}
 
 						SortOrder.RATING -> {}
+
 						else -> payload["vars[meta_key]"] = "_latest_update"
 					}
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/Ero18x.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/Ero18x.kt
@@ -7,6 +7,7 @@ import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
 import org.koitharu.kotatsu.parsers.util.generateUid
@@ -21,6 +22,8 @@ internal class Ero18x(context: MangaLoaderContext) :
 	override val datePattern = "MM/dd"
 	override val sourceLocale: Locale = Locale.ENGLISH
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 
 	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
 		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/Manhwa18Cc.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/Manhwa18Cc.kt
@@ -15,6 +15,8 @@ internal class Manhwa18Cc(context: MangaLoaderContext) :
 	override val listUrl = "webtoons/"
 	override val tagPrefix = "webtoon-genre/"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val selectTestAsync = "ul.row-content-chapter"
 	override val selectDate = "span.chapter-time"
 	override val selectChapter = "li.a-h"

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/ManhwaRaw.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/all/ManhwaRaw.kt
@@ -7,18 +7,22 @@ import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrlOrNull
 import org.koitharu.kotatsu.parsers.util.generateUid
 import org.koitharu.kotatsu.parsers.util.mapChapters
 import org.koitharu.kotatsu.parsers.util.parseFailed
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANHWARAW", "ManhwaRaw", "", ContentType.HENTAI)
 internal class ManhwaRaw(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANHWARAW, "manhwa-raw.com", 10) {
 	override val datePattern = "MM/dd"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 
 	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
 		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/GateManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/GateManga.kt
@@ -3,7 +3,9 @@ package org.koitharu.kotatsu.parsers.site.madara.ar
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("GATEMANGA", "GateManga", "ar")
 internal class GateManga(context: MangaLoaderContext) :
@@ -12,4 +14,7 @@ internal class GateManga(context: MangaLoaderContext) :
 	override val datePattern = "d MMMM، yyyy"
 	override val listUrl = "ar/"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
+
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/AdultWebtoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/AdultWebtoon.kt
@@ -16,6 +16,7 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("ADULT_WEBTOON", "AdultWebtoon", "en", ContentType.HENTAI)
 internal class AdultWebtoon(context: MangaLoaderContext) :
@@ -24,6 +25,8 @@ internal class AdultWebtoon(context: MangaLoaderContext) :
 	override val listUrl = "adult-webtoon/"
 	override val postReq = true
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 
 	override val availableStates: Set<MangaState> = emptySet()
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/BestManhuaCom.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/BestManhuaCom.kt
@@ -3,10 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("BESTMANHUACOM", "BestManhua.com", "en")
 internal class BestManhuaCom(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.BESTMANHUACOM, "bestmanhua.com", 10) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
+
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai3z.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai3z.kt
@@ -5,11 +5,16 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken // Redirect to @hentai20
 @MangaSourceParser("HENTAI3Z", "Hentai3z", "en", ContentType.HENTAI)
 internal class Hentai3z(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HENTAI3Z, "manga18h.xyz", pageSize = 20) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
+
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai4Free.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Hentai4Free.kt
@@ -6,6 +6,7 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
+import java.util.EnumSet
 
 @MangaSourceParser("HENTAI_4FREE", "Hentai4Free", "en", ContentType.HENTAI)
 internal class Hentai4Free(context: MangaLoaderContext) :
@@ -14,6 +15,8 @@ internal class Hentai4Free(context: MangaLoaderContext) :
 	override val tagPrefix = "hentai-tag/"
 	override val listUrl = ""
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val datePattern = "MMMM dd, yyyy"
 	override val selectGenre = "div.tags-content a"
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HentaiManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HentaiManga.kt
@@ -16,12 +16,15 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("HENTAIMANGA", "HentaiManga", "en", ContentType.HENTAI)
 internal class HentaiManga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HENTAIMANGA, "hentaimanga.me", 36) {
 	override val postReq = true
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val availableStates: Set<MangaState> = emptySet()
 	override val availableContentRating: Set<ContentRating> = emptySet()
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HentaiWebtoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HentaiWebtoon.kt
@@ -16,12 +16,15 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("HENTAIWEBTOON", "HentaiWebtoon", "en", ContentType.HENTAI)
 internal class HentaiWebtoon(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HENTAIWEBTOON, "hentaiwebtoon.com") {
 	override val postReq = true
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val availableStates: Set<MangaState> = emptySet()
 	override val availableContentRating: Set<ContentRating> = emptySet()
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HuntersScanEn.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/HuntersScanEn.kt
@@ -3,12 +3,16 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("HUNTERSSCANEN", "EnHuntersScan", "en")
 internal class HuntersScanEn(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HUNTERSSCANEN, "en.huntersscan.xyz") {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val datePattern = "MM/dd/yyyy"
 	override val tagPrefix = "series-genre/"
 	override val listUrl = "manga/"

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/IsekaiScanEuParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/IsekaiScanEuParser.kt
@@ -5,6 +5,7 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
+import java.util.EnumSet
 
 @MangaSourceParser("ISEKAISCAN_EU", "ParagonScans", "en")
 internal class IsekaiScanEuParser(context: MangaLoaderContext) :
@@ -12,6 +13,8 @@ internal class IsekaiScanEuParser(context: MangaLoaderContext) :
 
 	override val datePattern = "MM/dd/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val listUrl = "mangax/"
 
 	init {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manga1k.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manga1k.kt
@@ -5,11 +5,15 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("MANGA1K", "Manga1k", "en", ContentType.HENTAI)
 internal class Manga1k(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANGA1K, "manga1k.com", 20) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manga68.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manga68.kt
@@ -4,11 +4,15 @@ import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("MANGA68", "Manga68", "en")
 internal class Manga68(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANGA68, "manga68.com") {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDass.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDass.kt
@@ -9,6 +9,7 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANGADASS", "MangaDass", "en", ContentType.HENTAI)
 internal class MangaDass(context: MangaLoaderContext) :
@@ -16,6 +17,8 @@ internal class MangaDass(context: MangaLoaderContext) :
 
 	override val datePattern = "dd MMM yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val selectChapter = "li.a-h"
 	override val selectDesc = "div.ss-manga"
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDna.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDna.kt
@@ -9,6 +9,7 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANGADNA", "MangaDna", "en", ContentType.HENTAI)
 internal class MangaDna(context: MangaLoaderContext) :
@@ -16,6 +17,8 @@ internal class MangaDna(context: MangaLoaderContext) :
 
 	override val datePattern = "dd MMM yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val selectDesc = "div.dsct"
 	override val selectChapter = "li.a-h"
 	override val availableStates: Set<MangaState> = emptySet()

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaEffect.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaEffect.kt
@@ -4,7 +4,9 @@ import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("MANGAEFFECT", "MangaEffect", "en")
@@ -12,4 +14,6 @@ internal class MangaEffect(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANGAEFFECT, "mangaeffect.com") {
 	override val datePattern = "dd.MM.yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaFastNet.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaFastNet.kt
@@ -3,10 +3,14 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("MANGAFASTNET", "MangaFast.net", "en")
 internal class MangaFastNet(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANGAFASTNET, "manhuafast.net") {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaRead.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaRead.kt
@@ -3,7 +3,9 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("MANGAREAD", "MangaRead", "en")
 internal class MangaRead(context: MangaLoaderContext) :
@@ -11,4 +13,6 @@ internal class MangaRead(context: MangaLoaderContext) :
 	override val tagPrefix = "genres/"
 	override val datePattern = "dd.MM.yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangaus.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangaus.kt
@@ -4,11 +4,15 @@ import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("MANGAUS", "Mangaus", "en")
 internal class Mangaus(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANGAUS, "mangaus.xyz") {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhuaplus.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhuaplus.kt
@@ -6,14 +6,18 @@ import org.koitharu.kotatsu.parsers.exception.ParseException
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaPage
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
+import java.util.EnumSet
 
 @MangaSourceParser("MANHUAPLUS", "ManhuaPlus", "en")
 internal class Manhuaplus(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANHUAPLUS, "manhuaplus.com") {
 
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 
 	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
 		val fullUrl = chapter.url.toAbsoluteUrl(domain)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhuauss.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Manhuauss.kt
@@ -3,10 +3,14 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("MANHUAUSS", "Manhuauss", "en")
 internal class Manhuauss(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANHUAUSS, "manhuauss.com") {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ManhwaHentai.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ManhwaHentai.kt
@@ -11,9 +11,11 @@ import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.model.MangaState
 import org.koitharu.kotatsu.parsers.model.MangaTag
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANHWAHENTAI", "ManhwaHentai", "en", ContentType.HENTAI)
 internal class ManhwaHentai(context: MangaLoaderContext) :
@@ -21,6 +23,8 @@ internal class ManhwaHentai(context: MangaLoaderContext) :
 	override val tagPrefix = "webtoon-genre/"
 	override val listUrl = "webtoon/"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val postReq = true
 
 	override suspend fun getDetails(manga: Manga): Manga = coroutineScope {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ManyToon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ManyToon.kt
@@ -16,6 +16,7 @@ import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANYTOON", "ManyToon", "en", ContentType.HENTAI)
 internal class ManyToon(context: MangaLoaderContext) :
@@ -23,6 +24,8 @@ internal class ManyToon(context: MangaLoaderContext) :
 	override val listUrl = "comic/"
 	override val postReq = true
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 
 	override val availableStates: Set<MangaState> = emptySet()
 

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MmScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MmScans.kt
@@ -4,7 +4,9 @@ import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("MMSCANS", "MmScans", "en")
@@ -13,4 +15,6 @@ internal class MmScans(context: MangaLoaderContext) :
 	override val selectChapter = "li.chapter-li"
 	override val selectDesc = "div.summary-text"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MurimScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MurimScan.kt
@@ -3,12 +3,16 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("MURIMSCAN", "InkReads", "en")
 internal class MurimScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MURIMSCAN, "inkreads.com", 100) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val postReq = true
 	override val listUrl = "mangax/"
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ToonGod.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/ToonGod.kt
@@ -4,7 +4,9 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("TOONGOD", "ToonGod", "en", ContentType.HENTAI)
 internal class ToonGod(context: MangaLoaderContext) :
@@ -13,4 +15,6 @@ internal class ToonGod(context: MangaLoaderContext) :
 	override val tagPrefix = "webtoon-genre/"
 	override val datePattern = "d MMM yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Zinmanga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Zinmanga.kt
@@ -3,11 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("ZINMANGA", "ZinManga.net", "en")
 internal class Zinmanga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.ZINMANGA, "zinmanga.net") {
 	override val datePattern = "MM/dd/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ManhwaEs.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ManhwaEs.kt
@@ -6,18 +6,22 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.attrAsRelativeUrl
 import org.koitharu.kotatsu.parsers.util.generateUid
 import org.koitharu.kotatsu.parsers.util.mapChapters
 import org.koitharu.kotatsu.parsers.util.selectFirstOrThrow
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANHWA_ES", "Manhwa-Es", "es")
 internal class ManhwaEs(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANHWA_ES, "manhwa-es.com", 10) {
 
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val datePattern = "MM/dd"
 
 	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ManhwaLatino.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/ManhwaLatino.kt
@@ -7,9 +7,11 @@ import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.Manga
 import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
+import java.util.EnumSet
 
 @MangaSourceParser("MANHWALATINO", "ManhwaLatino", "es", ContentType.HENTAI)
 internal class ManhwaLatino(context: MangaLoaderContext) :
@@ -17,6 +19,8 @@ internal class ManhwaLatino(context: MangaLoaderContext) :
 
 	override val datePattern = "MM/dd"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val selectPage = "div.page-break img.wp-manga-chapter-img"
 	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
 		val root2 = doc.body().selectFirstOrThrow("div.content-area")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Vermanhwa.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Vermanhwa.kt
@@ -4,10 +4,14 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("VERMANHWA", "Vermanhwa", "es", ContentType.HENTAI)
 internal class Vermanhwa(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.VERMANHWA, "vermanhwa.com", 10) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Indo18h.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/id/Indo18h.kt
@@ -5,11 +5,15 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("INDO18H", "Indo18h", "id", ContentType.HENTAI)
 internal class Indo18h(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.INDO18H, "indo18h.com", 24) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/AncientComics.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/AncientComics.kt
@@ -4,7 +4,9 @@ import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @Broken
 @MangaSourceParser("ANCIENTCOMICS", "AncientComics", "pt")
@@ -12,4 +14,6 @@ internal class AncientComics(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.ANCIENTCOMICS, "ancientcomics.com.br") {
 	override val datePattern: String = "dd/MM/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atemporal.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atemporal.kt
@@ -3,11 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.pt
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("ATEMPORAL", "Atemporal", "pt")
 internal class Atemporal(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.ATEMPORAL, "atemporal.cloud") {
 	override val datePattern: String = "d 'de' MMMM 'de' yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/GalinhaSamurai.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/GalinhaSamurai.kt
@@ -3,11 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.pt
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("GALINHASAMURAI", "GalinhaSamurai", "pt")
 internal class GalinhaSamurai(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.GALINHASAMURAI, "galinhasamurai.com") {
 	override val datePattern = "dd/MM/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/HuntersScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/HuntersScan.kt
@@ -3,12 +3,16 @@ package org.koitharu.kotatsu.parsers.site.madara.pt
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("HUNTERSSCAN", "HuntersScan", "pt")
 internal class HuntersScan(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HUNTERSSCAN, "huntersscan.net", pageSize = 50) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val datePattern = "MM/dd/yyyy"
 	override val tagPrefix = "series-genre/"
 	override val listUrl = "series/"

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ImperiodaBritannia.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/ImperiodaBritannia.kt
@@ -3,11 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.pt
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("IMPERIODABRITANNIA", "ImperioDaBritannia", "pt")
 internal class ImperiodaBritannia(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.IMPERIODABRITANNIA, "imperiodabritannia.com", 10) {
 	override val datePattern: String = "dd 'de' MMMMM 'de' yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Norterose.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Norterose.kt
@@ -3,11 +3,15 @@ package org.koitharu.kotatsu.parsers.site.madara.pt
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("NORTEROSE", "Norterose", "pt")
 internal class Norterose(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.NORTEROSE, "norterose.com.br", 10) {
 	override val datePattern: String = "dd/MM/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Cat300.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Cat300.kt
@@ -4,10 +4,14 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("CAT_300", "Cat300", "th", ContentType.HENTAI)
 internal class Cat300(context: MangaLoaderContext) : MadaraParser(context, MangaParserSource.CAT_300, "cat300.net") {
 	override val datePattern = "MMMM dd, yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Doujinza.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Doujinza.kt
@@ -4,12 +4,16 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("DOUJINZA", "Doujinza", "th", ContentType.HENTAI)
 internal class Doujinza(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.DOUJINZA, "doujinza.com", 24) {
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 	override val datePattern = "MMMM dd, yyyy"
 	override val listUrl = "doujin/"
 	override val tagPrefix = "doujin-genre/"

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RuyaManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/RuyaManga.kt
@@ -3,7 +3,9 @@ package org.koitharu.kotatsu.parsers.site.madara.tr
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.SortOrder
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import java.util.EnumSet
 
 @MangaSourceParser("RUYAMANGA", "RuyaManga", "tr")
 internal class RuyaManga(context: MangaLoaderContext) :
@@ -11,4 +13,6 @@ internal class RuyaManga(context: MangaLoaderContext) :
 	override val tagPrefix = "manga-kategori/"
 	override val datePattern = "dd/MM/yyyy"
 	override val withoutAjax = true
+	override val availableSortOrders: Set<SortOrder> =
+		EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.RATING)
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mmrcms/MmrcmsParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mmrcms/MmrcmsParser.kt
@@ -27,6 +27,7 @@ internal abstract class MmrcmsParser(
 
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
 		SortOrder.POPULARITY,
+		SortOrder.POPULARITY_ASC,
 		SortOrder.UPDATED,
 		SortOrder.ALPHABETICAL,
 		SortOrder.ALPHABETICAL_DESC,
@@ -110,6 +111,7 @@ internal abstract class MmrcmsParser(
 						append("&sortBy=")
 						when (filter.sortOrder) {
 							SortOrder.POPULARITY -> append("views&asc=false")
+							SortOrder.POPULARITY_ASC -> append("views&asc=true")
 							SortOrder.ALPHABETICAL -> append("name&asc=true")
 							SortOrder.ALPHABETICAL_DESC -> append("name&asc=false")
 							else -> append("name")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/pt/LerManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/pt/LerManga.kt
@@ -14,10 +14,13 @@ class LerManga(context: MangaLoaderContext) : PagedMangaParser(context, MangaPar
 	override val availableSortOrders: Set<SortOrder> =
 		EnumSet.of(
 			SortOrder.UPDATED,
+			SortOrder.UPDATED_ASC,
 			SortOrder.POPULARITY,
+			SortOrder.POPULARITY_ASC,
 			SortOrder.ALPHABETICAL,
 			SortOrder.ALPHABETICAL_DESC,
 			SortOrder.RATING,
+			SortOrder.RATING_ASC,
 		)
 
 	override val configKeyDomain = ConfigKey.Domain("lermanga.org")
@@ -60,10 +63,13 @@ class LerManga(context: MangaLoaderContext) : PagedMangaParser(context, MangaPar
 					append(
 						when (filter.sortOrder) {
 							SortOrder.UPDATED -> "modified&order=desc"
+							SortOrder.UPDATED_ASC -> "modified&order=asc"
 							SortOrder.POPULARITY -> "views&order=desc"
+							SortOrder.POPULARITY_ASC -> "views&order=asc"
 							SortOrder.ALPHABETICAL -> "title&order=asc"
 							SortOrder.ALPHABETICAL_DESC -> "title&order=desc"
 							SortOrder.RATING -> "rating&order=desc"
+							SortOrder.RATING_ASC -> "rating&order=asc"
 							else -> "modified&order=desc"
 						},
 					)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/MangaWtfParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/MangaWtfParser.kt
@@ -69,6 +69,10 @@ class MangaWtfParser(
 						SortOrder.NEWEST -> "createdAt,desc"
 						SortOrder.ALPHABETICAL,
 						SortOrder.ALPHABETICAL_DESC,
+						SortOrder.UPDATED_ASC,
+						SortOrder.POPULARITY_ASC,
+						SortOrder.RATING_ASC,
+						SortOrder.NEWEST_ASC,
 						-> throw IllegalArgumentException("Unsupported ${filter.sortOrder}")
 					},
 				)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/LibSocialParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/LibSocialParser.kt
@@ -21,7 +21,7 @@ internal abstract class LibSocialParser(
 	protected val siteId: Int,
 ) : PagedMangaParser(context, source, pageSize = 60) {
 
-	override val availableSortOrders: Set<SortOrder> = EnumSet.allOf(SortOrder::class.java)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
 
 	final override val configKeyDomain = ConfigKey.Domain("lib.social")
 	override val availableStates: Set<MangaState> = EnumSet.allOf(MangaState::class.java)
@@ -88,6 +88,7 @@ internal abstract class LibSocialParser(
 				SortOrder.ALPHABETICAL,
 				SortOrder.ALPHABETICAL_DESC,
 				-> "rus_name"
+				else -> null
 			},
 		)
 		urlBuilder.addQueryParameter(
@@ -101,6 +102,7 @@ internal abstract class LibSocialParser(
 				-> "desc"
 
 				SortOrder.ALPHABETICAL -> "asc"
+				else -> null
 			},
 		)
 		val json = webClient.httpGet(urlBuilder.build()).parseJson()

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/LibSocialParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/rulib/LibSocialParser.kt
@@ -21,7 +21,14 @@ internal abstract class LibSocialParser(
 	protected val siteId: Int,
 ) : PagedMangaParser(context, source, pageSize = 60) {
 
-	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.UPDATED,
+		SortOrder.POPULARITY,
+		SortOrder.RATING,
+		SortOrder.NEWEST,
+		SortOrder.ALPHABETICAL,
+		SortOrder.ALPHABETICAL_DESC,
+	)
 
 	final override val configKeyDomain = ConfigKey.Domain("lib.social")
 	override val availableStates: Set<MangaState> = EnumSet.allOf(MangaState::class.java)
@@ -88,6 +95,7 @@ internal abstract class LibSocialParser(
 				SortOrder.ALPHABETICAL,
 				SortOrder.ALPHABETICAL_DESC,
 				-> "rus_name"
+
 				else -> null
 			},
 		)

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/tr/TrWebtoon.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/tr/TrWebtoon.kt
@@ -23,7 +23,13 @@ class TrWebtoon(context: MangaLoaderContext) :
 	}
 
 	override val availableSortOrders: Set<SortOrder> =
-		EnumSet.of(SortOrder.POPULARITY, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC, SortOrder.UPDATED)
+		EnumSet.of(
+			SortOrder.POPULARITY,
+			SortOrder.POPULARITY_ASC,
+			SortOrder.ALPHABETICAL,
+			SortOrder.ALPHABETICAL_DESC,
+			SortOrder.UPDATED,
+		)
 
 	override val availableStates: Set<MangaState> = EnumSet.of(MangaState.ONGOING, MangaState.FINISHED)
 
@@ -80,6 +86,7 @@ class TrWebtoon(context: MangaLoaderContext) :
 						append("&sort=")
 						when (filter.sortOrder) {
 							SortOrder.POPULARITY -> append("views&short_type=DESC")
+							SortOrder.POPULARITY_ASC -> append("views&short_type=ASC")
 							SortOrder.ALPHABETICAL -> append("name&short_type=ASC")
 							SortOrder.ALPHABETICAL_DESC -> append("name&short_type=DESC")
 							else -> append("views&short_type=DESC")

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenLL.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenLL.kt
@@ -24,7 +24,14 @@ internal class NetTruyenLL(context: MangaLoaderContext) :
 	override val listUrl = "/tim-kiem-nang-cao"
 	override val availableStates: Set<MangaState> =
 		EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.PAUSED, MangaState.ABANDONED)
-	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.UPDATED,
+		SortOrder.POPULARITY,
+		SortOrder.RATING,
+		SortOrder.NEWEST,
+		SortOrder.ALPHABETICAL,
+		SortOrder.ALPHABETICAL_DESC,
+	)
 
 	override suspend fun getListPage(page: Int, filter: MangaListFilter?): List<Manga> {
 		val response =

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenLL.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenLL.kt
@@ -24,7 +24,7 @@ internal class NetTruyenLL(context: MangaLoaderContext) :
 	override val listUrl = "/tim-kiem-nang-cao"
 	override val availableStates: Set<MangaState> =
 		EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.PAUSED, MangaState.ABANDONED)
-	override val availableSortOrders: Set<SortOrder> = EnumSet.allOf(SortOrder::class.java)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
 
 	override suspend fun getListPage(page: Int, filter: MangaListFilter?): List<Manga> {
 		val response =
@@ -93,6 +93,7 @@ internal class NetTruyenLL(context: MangaLoaderContext) :
 								SortOrder.RATING -> "score"
 								SortOrder.ALPHABETICAL -> "az"
 								SortOrder.ALPHABETICAL_DESC -> "za"
+								else -> null
 							},
 						)
 					}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenSSR.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenSSR.kt
@@ -24,7 +24,7 @@ internal class NetTruyenSSR(context: MangaLoaderContext) :
 	override val listUrl = "/tim-kiem-nang-cao"
 	override val availableStates: Set<MangaState> =
 		EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.PAUSED, MangaState.ABANDONED)
-	override val availableSortOrders: Set<SortOrder> = EnumSet.allOf(SortOrder::class.java)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
 
 	override suspend fun getListPage(page: Int, filter: MangaListFilter?): List<Manga> {
 		val response =
@@ -93,6 +93,7 @@ internal class NetTruyenSSR(context: MangaLoaderContext) :
 								SortOrder.RATING -> "score"
 								SortOrder.ALPHABETICAL -> "az"
 								SortOrder.ALPHABETICAL_DESC -> "za"
+								else -> null
 							},
 						)
 					}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenSSR.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/wpcomics/vi/NetTruyenSSR.kt
@@ -24,7 +24,14 @@ internal class NetTruyenSSR(context: MangaLoaderContext) :
 	override val listUrl = "/tim-kiem-nang-cao"
 	override val availableStates: Set<MangaState> =
 		EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.PAUSED, MangaState.ABANDONED)
-	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.UPDATED,
+		SortOrder.POPULARITY,
+		SortOrder.RATING,
+		SortOrder.NEWEST,
+		SortOrder.ALPHABETICAL,
+		SortOrder.ALPHABETICAL_DESC,
+	)
 
 	override suspend fun getListPage(page: Int, filter: MangaListFilter?): List<Manga> {
 		val response =

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zmanga/ZMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zmanga/ZMangaParser.kt
@@ -26,7 +26,7 @@ internal abstract class ZMangaParser(
 		keys.add(userAgentKey)
 	}
 
-	override val availableSortOrders: Set<SortOrder> = EnumSet.allOf(SortOrder::class.java)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
 
 	override val availableStates: Set<MangaState> = EnumSet.of(MangaState.ONGOING, MangaState.FINISHED)
 
@@ -80,6 +80,7 @@ internal abstract class ZMangaParser(
 						SortOrder.ALPHABETICAL_DESC -> append("titlereverse")
 						SortOrder.NEWEST -> append("latest")
 						SortOrder.RATING -> append("rating")
+						else -> null
 					}
 
 					filter.tags.forEach {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zmanga/ZMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zmanga/ZMangaParser.kt
@@ -26,7 +26,14 @@ internal abstract class ZMangaParser(
 		keys.add(userAgentKey)
 	}
 
-	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.UPDATED, SortOrder.POPULARITY, SortOrder.RATING, SortOrder.NEWEST, SortOrder.ALPHABETICAL, SortOrder.ALPHABETICAL_DESC)
+	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
+		SortOrder.UPDATED,
+		SortOrder.POPULARITY,
+		SortOrder.RATING,
+		SortOrder.NEWEST,
+		SortOrder.ALPHABETICAL,
+		SortOrder.ALPHABETICAL_DESC,
+	)
 
 	override val availableStates: Set<MangaState> = EnumSet.of(MangaState.ONGOING, MangaState.FINISHED)
 


### PR DESCRIPTION
For some sources, there is an asc and desc option, so I think it would be good to implement the different options in the sorting filter.

For the moment I've only adapted mangaDex and TuMangaOnline, but others are bound to be compatible with these sortings too.

edit: I've just added another source including the madara template which, if the source uses the list via ajax, it's possible to use its sorting filters.