### PR TITLE
[NHentai.xxx] Fix source

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/galleryadults/all/NHentaiXxxParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/galleryadults/all/NHentaiXxxParser.kt
@@ -32,6 +32,8 @@ internal class NHentaiXxxParser(context: MangaLoaderContext) :
 	override val filterCapabilities: MangaListFilterCapabilities
 		get() = super.filterCapabilities.copy(
 			isMultipleTagsSupported = true,
+			isSearchSupported = true,
+			isSearchWithFiltersSupported = true,
 		)
 
 	override suspend fun getFilterOptions() = super.getFilterOptions().copy(
@@ -61,7 +63,7 @@ internal class NHentaiXxxParser(context: MangaLoaderContext) :
 
 					val joiner = StringUtil.StringJoiner("+")
 					tags.forEach { tag ->
-						joiner.add(tag.key.replace(" ","-"))
+						joiner.add(tag.title)
 					}
 
 					if(!filter.query.isNullOrEmpty()) {


### PR DESCRIPTION
It seems they updated they search endpoint now it doesn't work with `-` for multi-word tags which is present in `key` but not in `title`.   
`key` part left unchanged cause key can be used in dedicated tag/author endpoint as path value    
    
 Also now search support title name search with and without tags and author search