### PR TITLE
Update FlameComics large cover art url

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/FlameComics.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/FlameComics.kt
@@ -156,7 +156,7 @@ internal class FlameComics(context: MangaLoaderContext) :
 			},
 			authors = setOfNotNull(author),
 			largeCoverUrl = if (cover != null) {
-				imageUrl(seriesId, cover, 640)
+				imageUrl(seriesId, cover, 720)
 			} else {
 				null
 			},


### PR DESCRIPTION
They changed the url to 720 here is the url for proof 
now: https://flamecomics.xyz/_next/image?url=https%3A%2F%2Fcdn.flamecomics.xyz%2Fseries%2F133%2Fthumbnail.png&w=640&q=100
the updatet: https://flamecomics.xyz/_next/image?url=https%3A%2F%2Fcdn.flamecomics.xyz%2Fseries%2F133%2Fthumbnail.png&w=720&q=100