### PR TITLE
[Hitomi.La] Change cdn domain & fix image url logic

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
@@ -752,12 +752,4 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 			.replace("♂", "(male)")
 			.replace("♀", "(female)")
 	}
-
-	private suspend fun getThumbnailUrl(hash: String): String {
-		val commonId = commonImageId()
-		val imageId = imageIdFromHash(hash)
-		val subDomain = 'a' + subdomainOffset(imageId)
-
-		return "https://${subDomain}tn.$cdnDomain/avifbigtn/${thumbPathFromHash(hash)}/$hash.avif"
-	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
@@ -31,12 +31,14 @@ import kotlin.math.min
 internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(context, MangaParserSource.HITOMILA) {
 	override val configKeyDomain = ConfigKey.Domain("hitomi.la")
 
+	private val cdnDomain = "gold-usergeneratedcontent.net"
+
 	override fun onCreateConfig(keys: MutableCollection<ConfigKey<*>>) {
 		super.onCreateConfig(keys)
 		keys.add(userAgentKey)
 	}
 
-	private val ltnBaseUrl get() = "https://${getDomain("ltn")}"
+	private val ltnBaseUrl get() = "https://ltn.$cdnDomain"
 
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
 		SortOrder.NEWEST,
@@ -556,7 +558,7 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 					val imageId = imageIdFromHash(hash)
 					val subDomain = 'a' + subdomainOffset(imageId)
 
-					"https://${getDomain("${subDomain}a")}/webp/$commonId$imageId/$hash.webp"
+					"https://${subDomain}tn.$cdnDomain/avifbigtn/${thumbPathFromHash(hash)}/$hash.avif"
 				},
 			authors = setOfNotNull(author),
 			publicUrl = json.getString("galleryurl").toAbsoluteUrl(domain),
@@ -656,12 +658,12 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 			val hash = image.getString("hash")
 			val commonId = commonImageId()
 			val imageId = imageIdFromHash(hash)
-			val subDomain = 'a' + subdomainOffset(imageId)
+			val subDomain = subdomainOffset(imageId) + 1
 
 			MangaPage(
 				id = generateUid(hash),
-				url = "https://${getDomain("${subDomain}a")}/webp/$commonId$imageId/$hash.webp",
-				preview = "https://${getDomain("${subDomain}tn")}/webpsmalltn/${thumbPathFromHash(hash)}/$hash.webp",
+				url = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif",
+				preview = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif", // need fix ?
 				source = source,
 			)
 		}
@@ -749,5 +751,13 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 		return toCamelCase()
 			.replace("♂", "(male)")
 			.replace("♀", "(female)")
+	}
+
+	private suspend fun getThumbnailUrl(hash: String): String {
+		val commonId = commonImageId()
+		val imageId = imageIdFromHash(hash)
+		val subDomain = 'a' + subdomainOffset(imageId)
+
+		return "https://${subDomain}tn.$cdnDomain/avifbigtn/${thumbPathFromHash(hash)}/$hash.avif"
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
@@ -663,7 +663,7 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 			MangaPage(
 				id = generateUid(hash),
 				url = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif",
-				preview = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif", // need fix ?
+				preview = null, // need fix / alternative ?
 				source = source,
 			)
 		}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
@@ -663,7 +663,7 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 			MangaPage(
 				id = generateUid(hash),
 				url = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif",
-				preview = null, // need fix / alternative ?
+				preview = "https://${thumbSubdomain}tn.$cdnDomain/webpsmalltn/${thumbPathFromHash(hash)}/$hash.webp",
 				source = source,
 			)
 		}

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/HitomiLaParser.kt
@@ -659,7 +659,7 @@ internal class HitomiLaParser(context: MangaLoaderContext) : LegacyMangaParser(c
 			val commonId = commonImageId()
 			val imageId = imageIdFromHash(hash)
 			val subDomain = subdomainOffset(imageId) + 1
-
+			val thumbSubdomain = 'a' + subdomainOffset(imageId)
 			MangaPage(
 				id = generateUid(hash),
 				url = "https://a${subDomain}.$cdnDomain/$commonId$imageId/$hash.avif",


### PR DESCRIPTION
Seems largeCoverUrl + preview images for chapter are broken...
Reference from https://github.com/keiyoushi/extensions-source/pull/8204 by @AwkwardPeak7, tks.

Solved #1602 