### PR TITLE
Update domain list of Desu

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
@@ -8,8 +8,7 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.core.LegacyPagedMangaParser
 import org.koitharu.kotatsu.parsers.exception.ParseException
-import org.koitharu.kotatsu.parsers.model.*шьзщке щкпюлщшерфкгюлщефеыгюзфкыукыюьщвудю;
-
+import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.network.UserAgents
 import org.koitharu.kotatsu.parsers.util.*
 import org.koitharu.kotatsu.parsers.util.json.*

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
@@ -8,7 +8,8 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.core.LegacyPagedMangaParser
 import org.koitharu.kotatsu.parsers.exception.ParseException
-import org.koitharu.kotatsu.parsers.model.*
+import org.koitharu.kotatsu.parsers.model.*шьзщке щкпюлщшерфкгюлщефеыгюзфкыукыюьщвудю;
+
 import org.koitharu.kotatsu.parsers.network.UserAgents
 import org.koitharu.kotatsu.parsers.util.*
 import org.koitharu.kotatsu.parsers.util.json.*
@@ -20,7 +21,7 @@ import java.util.*
 internal class DesuMeParser(context: MangaLoaderContext) :
 	LegacyPagedMangaParser(context, MangaParserSource.DESUME, 20) {
 
-	override val configKeyDomain = ConfigKey.Domain("desu.me", "desu.win")
+	override val configKeyDomain = ConfigKey.Domain("desu.me", "desu.win", "desu.store")
 
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(
 		SortOrder.UPDATED,


### PR DESCRIPTION
Desu.me recently started new mirror domain "desu.store".  Moreover, original domain "desu.me" are down for several days, so it will be handy to have another option.